### PR TITLE
Small fix to `LastUpdated` column type

### DIFF
--- a/src/MondaySharp.NET/Domain/Common/Enums/MondayColumnType.cs
+++ b/src/MondaySharp.NET/Domain/Common/Enums/MondayColumnType.cs
@@ -19,7 +19,7 @@ public enum MondayColumnType
     Hour,
     Item_Assignees,
     Item_Id,
-    LastUpdated,
+    Last_Updated,
     Link,
     Location,
     Long_Text,

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
 		<PackageDescription>This package contains a Monday.com client</PackageDescription>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<Deterministic>False</Deterministic>
-		<Version>1.0.12</Version>
+		<Version>1.0.13</Version>
 		<PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
 	</PropertyGroup>
 


### PR DESCRIPTION
The current implementation of `LastUpdated` in `MondayColumnType` would result in an exception. I changed the enum to `Last_Updated` instead based on documentation which appears to fix the issue.