### PR TITLE
Create / Update Monday Row By Class + Bug Fixes

### DIFF
--- a/src/MondaySharp.NET/Application/Attributes/MondayColumnTypeUnsupportedWriteAttribute.cs
+++ b/src/MondaySharp.NET/Application/Attributes/MondayColumnTypeUnsupportedWriteAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace MondaySharp.NET.Application.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class MondayColumnTypeUnsupportedWriteAttribute : Attribute
+{
+}

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
@@ -9,6 +9,7 @@ public interface IMondayClient
     public Task<MondayResponse<T>> GetBoardItemsAsync<T>(ulong boardId, int limit = 25, CancellationToken cancellationToken = default) where T : MondayRow, new();
     public Task<MondayResponse<T>> GetBoardItemAsync<T>(ulong itemId) where T : MondayRow, new();
     public Task<MondayResponse<Dictionary<string, Item>?>> CreateBoardItemsAsync(ulong boardId, Item[] items, CancellationToken cancellationToken = default);
+    public Task<Application.MondayResponse<Dictionary<string, Item>?>> CreateBoardItemsAsync<T>(ulong boardId, T[] items, CancellationToken cancellationToken = default) where T : MondayRow;
     public Task<MondayResponse<Dictionary<string, Update>?>> CreateItemsUpdateAsync(Update[] updates, CancellationToken cancellationToken = default);
     public Task<MondayResponse<Dictionary<string, Item>?>> DeleteItemsAsync(Item[] items, CancellationToken cancellationToken = default);
     public Task<Application.MondayResponse<List<Board>>> GetBoardsAsync(ulong[]? boardIds = null, int limit = 10, CancellationToken cancellationToken = default);

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
@@ -7,14 +7,15 @@ public interface IMondayClient
 {
     public Task<MondayResponse<T>> GetBoardItemsAsync<T>(ulong boardId, ColumnValue[] columnValues, int limit = 25, CancellationToken cancellationToken = default) where T : MondayRow, new();
     public Task<MondayResponse<T>> GetBoardItemsAsync<T>(ulong boardId, int limit = 25, CancellationToken cancellationToken = default) where T : MondayRow, new();
-    public Task<MondayResponse<T>> GetBoardItemAsync<T>(ulong itemId) where T : MondayRow, new();
+    public Task<MondayResponse<T>> GetBoardItemAsync<T>(ulong itemId, CancellationToken cancellationToken = default) where T : MondayRow, new();
     public Task<MondayResponse<Dictionary<string, Item>?>> CreateBoardItemsAsync(ulong boardId, Item[] items, CancellationToken cancellationToken = default);
-    public Task<Application.MondayResponse<Dictionary<string, Item>?>> CreateBoardItemsAsync<T>(ulong boardId, T[] items, CancellationToken cancellationToken = default) where T : MondayRow;
+    public Task<Application.MondayResponse<Dictionary<ulong, T>?>> CreateBoardItemsAsync<T>(ulong boardId, T[] items, CancellationToken cancellationToken = default) where T : MondayRow, new();
     public Task<MondayResponse<Dictionary<string, Update>?>> CreateItemsUpdateAsync(Update[] updates, CancellationToken cancellationToken = default);
     public Task<MondayResponse<Dictionary<string, Item>?>> DeleteItemsAsync(Item[] items, CancellationToken cancellationToken = default);
     public Task<Application.MondayResponse<List<Board>>> GetBoardsAsync(ulong[]? boardIds = null, int limit = 10, CancellationToken cancellationToken = default);
     public Task<Application.MondayResponse<Dictionary<string, Asset>>> UploadFileToUpdateAsync(Update[] updates, CancellationToken cancellationToken = default);
     public Task<Application.MondayResponse<Dictionary<string, Asset>>> UploadFileToColumnAsync(Item[] items, CancellationToken cancellationToken = default);
     public Task<Application.MondayResponse<T>> GetBoardItemsAsync<T>(string? cursor, int limit = 25, CancellationToken cancellationToken = default) where T : MondayRow, new();
+    public Task<Application.MondayResponse<Dictionary<ulong, T>?>> UpdateBoardItemAsync<T>(ulong boardId, T[] items, CancellationToken cancellationToken = default) where T : MondayRow, new();
     public void Dispose();
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnCheckBox.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnCheckBox.cs
@@ -1,7 +1,7 @@
 ﻿namespace MondaySharp.NET.Domain.ColumnTypes;
 public record ColumnCheckBox : ColumnBaseType
 {
-    public bool IsChecked { get; }
+    public bool IsChecked { get; set; }
 
     public ColumnCheckBox() { }
 
@@ -20,5 +20,5 @@ public record ColumnCheckBox : ColumnBaseType
     /// 
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => "\"check\" : {\"checked\" : \"" + this.IsChecked.ToString().ToLower() + "\"}";
+    public override string ToString() => $"\"{this.Id}\" : {{\"checked\" : \"" + this.IsChecked.ToString().ToLower() + "\"}";
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnCheckBox.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnCheckBox.cs
@@ -20,5 +20,8 @@ public record ColumnCheckBox : ColumnBaseType
     /// 
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => $"\"{this.Id}\" : {{\"checked\" : \"" + this.IsChecked.ToString().ToLower() + "\"}";
+    public override string ToString()
+    {
+        return this.IsChecked ? $"\"check\" : {{\"checked\" : \"{this.IsChecked.ToString().ToLower()}\"}}" : $"\"{this.Id}\" : null";
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnColorPicker.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnColorPicker.cs
@@ -1,9 +1,17 @@
 ﻿
+using MondaySharp.NET.Application.Attributes;
+
 namespace MondaySharp.NET.Domain.ColumnTypes;
 
+[MondayColumnTypeUnsupportedWrite]
 public record ColumnColorPicker : ColumnBaseType
 {
     public string? Color { get; set; }
+
+    public ColumnColorPicker(string? id)
+    {
+        this.Id = id;
+    }
 
     public ColumnColorPicker(string? id, string? text)
     {

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDateTime.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDateTime.cs
@@ -6,6 +6,11 @@ public record ColumnDateTime : ColumnBaseType
     public DateTime? Date { get; set; }
     public bool IncludeTime { get; set; }
 
+    public ColumnDateTime(string? id)
+    {
+        this.Id = id;
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -33,6 +38,11 @@ public record ColumnDateTime : ColumnBaseType
 
     public override string ToString()
     {
+        if (this.Date == null)
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
         return this.IncludeTime
             ? "\"" + this.Id + "\" : {\"date\" : \"" + this.Date?.ToString("yyyy-MM-dd") + "\", \"time\" : \"" + this.Date?.ToString("HH:mm:ss") + "\"}"
             : "\"" + this.Id + "\" : {\"date\" : \"" + this.Date?.ToString("yyyy-MM-dd") + "\"}";

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDropDown.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDropDown.cs
@@ -66,13 +66,13 @@ public record ColumnDropDown : ColumnBaseType
             return $"\"{this.Id}\" : {{\"labels\":[{string.Join(",", this.Labels.Select(label => $"\"{label}\""))}]}}";
         }
 
-        if (this.LabelId != 0)
+        if (this.LabelId != null)
         {
             return $"\"{this.Id}\" : \"{this.LabelId}\"";
         }
         else
         {
-            return $"\"{this.Id}\" : \"{this.Label}\"";
+            return $"\"{this.Id}\" : null";
         }
     }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDropDown.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnDropDown.cs
@@ -56,6 +56,11 @@ public record ColumnDropDown : ColumnBaseType
 
     public override string ToString()
     {
+        if (this.Label != null)
+        {
+            return $"\"{this.Id}\" : {{\"labels\":[\"{this.Label}\"]}}";
+        }
+
         if (this.Labels != null && this.Labels.Length > 0)
         {
             return $"\"{this.Id}\" : {{\"labels\":[{string.Join(",", this.Labels.Select(label => $"\"{label}\""))}]}}";

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnEmailType.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnEmailType.cs
@@ -29,6 +29,11 @@ public record ColumnEmail : ColumnBaseType
     /// <returns></returns>
     public override string ToString()
     {
+        if (string.IsNullOrEmpty(this.Email))
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
         return "\"" + this.Id + "\":{\"email\":\"" + this.Email + "\",\"text\":\"" + (this.Message ?? this.Email) + "\"}";
     }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLink.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLink.cs
@@ -25,7 +25,6 @@ public record ColumnLink : ColumnBaseType
     public ColumnLink(string? id)
     {
         this.Id = id;
-        this.Uri = null;
     }
 
     /// <summary>
@@ -50,6 +49,11 @@ public record ColumnLink : ColumnBaseType
 
     public override string ToString()
     {
+        if (this.Uri == null)
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
         return "\"" + this.Id + "\" : {\"url\" : \"" + this.Uri?.OriginalString + "\", \"text\":\"" + this.Text + "\"}";
     }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLongText.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLongText.cs
@@ -5,6 +5,11 @@ public record ColumnLongText : ColumnBaseType
     public ColumnLongText() { }
     public string? Text { get; set; }
 
+    public ColumnLongText(string? id)
+    {
+        this.Id = id;
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -15,5 +20,13 @@ public record ColumnLongText : ColumnBaseType
         this.Id = id;
         this.Text = text;
     }
-    public override string ToString() => "\"" + this.Id + "\" : {\"text\" : \"" + this.Text + "\"}";
+    public override string ToString()
+    {
+        if (string.IsNullOrEmpty(this.Text))
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
+        return "\"" + this.Id + "\" : {\"text\" : \"" + this.Text + "\"}";
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnNumber.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnNumber.cs
@@ -23,5 +23,13 @@ public record ColumnNumber : ColumnBaseType
     /// 
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => "\"" + this.Id + "\" : \"" + this.Number + "\"";
+    public override string ToString()
+    {
+        if (this.Number == null)
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
+        return "\"" + this.Id + "\" : \"" + this.Number + "\"";
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnRating.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnRating.cs
@@ -8,6 +8,11 @@ public record ColumnRating : ColumnBaseType
 
     public ColumnRating() { }
 
+    public ColumnRating(string? id)
+    {
+        this.Id = id;
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -23,5 +28,8 @@ public record ColumnRating : ColumnBaseType
     /// 
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => $"\"{this.Id}\" : {{\"rating\" : {(int?)this.Rating ?? 0}}}";
+    public override string ToString()
+    {
+        return $"\"{this.Id}\" : {{\"rating\" : {(int?)this.Rating ?? 0}}}";
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnStatus.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnStatus.cs
@@ -5,6 +5,11 @@ public record ColumnStatus :ColumnBaseType
     public string? Status { get; set; }
     public int? StatusId { get; set; }
 
+    public ColumnStatus(string? id)
+    {
+        this.Id = id;
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -31,7 +36,20 @@ public record ColumnStatus :ColumnBaseType
     {
     }
 
-    public override string ToString() => string.IsNullOrEmpty(Status)
-            ? "\"" + this.Id + "\" : {\"index\" : \"" + this.StatusId + "\"}"
-            : "\"" + this.Id + "\" : {\"label\" : \"" + this.Status + "\"}";
+    public override string ToString()
+    {
+        if (this.Status == null && this.StatusId == null)
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
+        if (string.IsNullOrEmpty(Status))
+        {
+            return "\"" + this.Id + "\" : {\"index\" : \"" + this.StatusId + "\"}";
+        }
+        else
+        {
+            return "\"" + this.Id + "\" : {\"label\" : \"" + this.Status + "\"}";
+        }
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTag.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTag.cs
@@ -6,6 +6,11 @@ public record ColumnTag : ColumnBaseType
     public int[]? TagIds { get; set; }
     public string[]? Tags { get; set; }
 
+    public ColumnTag(string? id)
+    {
+        this.Id = id;
+    }
+
     public ColumnTag(string? id, string? text)
     {
         this.Id = id;
@@ -35,10 +40,11 @@ public record ColumnTag : ColumnBaseType
 
     public override string ToString()
     {
+
         return TagIds?.Length switch
         {
             > 0 => "\"" + Id + "\" : {\"tag_ids\" : [" + string.Join(",", TagIds) + "]}",
-            _ => "\"" + Id + "\" : {\"tag_ids\" : []}"
+            _ => "\"" + Id + "\" : null"
         };
     }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTag.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTag.cs
@@ -4,6 +4,7 @@ public record ColumnTag : ColumnBaseType
 {
     public ColumnTag() { }
     public int[]? TagIds { get; set; }
+    public string[]? Tags { get; set; }
 
     public ColumnTag(string? id, string? text)
     {
@@ -11,13 +12,18 @@ public record ColumnTag : ColumnBaseType
 
         if (!string.IsNullOrWhiteSpace(text))
         {
-            // Split at , and try parse into int array
+            // Split at , and try parse into int array if possible.
             this.TagIds = text
                 .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
                 .Select(s => int.TryParse(s, out int result) ? result : (int?)null)
                 .Where(i => i.HasValue)
                 .Select(i => i!.Value)
                 .ToArray();
+
+            if (this.TagIds.Length == 0)
+            {
+                this.Tags = text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            }
         }
     }
 

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnText.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnText.cs
@@ -27,5 +27,13 @@ public record ColumnText : ColumnBaseType
     /// 
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => "\"" + this.Id + "\" : \"" + this.Text + "\"";
+    public override string ToString()
+    {
+        if (string.IsNullOrEmpty(this.Text))
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
+        return "\"" + this.Id + "\" : \"" + this.Text + "\"";
+    }
 }

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTimeline.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnTimeline.cs
@@ -26,6 +26,11 @@ public record ColumnTimeline : ColumnBaseType
 
     public override string ToString()
     {
+        if (this.From == null && this.To == null)
+        {
+            return "\"" + this.Id + "\" : null";
+        }
+
         return this.From != null && this.To != null
             ? "\"" + this.Id + "\" : {\"from\" : \"" + this.From.Value.ToString("yyyy-MM-dd") + "\", \"to\" : \"" + this.To.Value.ToString("yyyy-MM-dd") + "\"}"
             : base.ToString();

--- a/src/MondaySharp.NET/Domain/Common/MondayRow.cs
+++ b/src/MondaySharp.NET/Domain/Common/MondayRow.cs
@@ -1,9 +1,13 @@
-﻿using MondaySharp.NET.Domain.ColumnTypes;
+﻿using MondaySharp.NET.Application.Attributes;
+using MondaySharp.NET.Domain.ColumnTypes;
 
 namespace MondaySharp.NET.Domain.Common;
 
 public record MondayRow
 {
+    [MondayColumnHeader("id")]
     public ulong Id { get; set; }
+
+    [MondayColumnHeader("name")]
     public ColumnText? Name { get; set; }
 }

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
 		<PackageDescription>This package contains a Monday.com client</PackageDescription>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<Deterministic>False</Deterministic>
-		<Version>1.0.19</Version>
+		<Version>1.0.20</Version>
 		<PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
 	</PropertyGroup>
 

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 namespace MondaySharp.Functional.Tests;
 
 [TestClass]
-public class UnitTest1
+public class FunctionalTests
 {
     IMondayClient? MondayClient { get; set; }
     IConfiguration? Configuration { get; set; } = null!;
@@ -767,6 +767,85 @@ public class UnitTest1
     }
 
     [TestMethod]
+    public async Task CreateItemFromMondayRow_Should_Be_Ok()
+    {
+        // Arrange
+        TestRow testRow = new()
+        {
+            Name = new ColumnText()
+            {
+                Text = "Test Item 1"
+            },
+            Text = new ColumnText()
+            {
+                Text = "Andrew Eberle"
+            },
+            Number = new ColumnNumber()
+            {
+                Number = 10
+            },
+            Email = new ColumnEmail()
+            {
+                Email = "andrew.eberle@lithocraft.com.au"
+            },
+            Rating = new ColumnRating()
+            {
+                Rating = MondayRating.Five
+            },
+            Checkbox = new ColumnCheckBox()
+            {
+                IsChecked = true
+            },
+            Date = new ColumnDateTime()
+            {
+                Date = new DateTime(2023, 11, 29)
+            },
+            Dropdown = new ColumnDropDown()
+            {
+                Label = "Hello"
+            },
+            LongText = new ColumnLongText()
+            {
+                Text = "Hello, World!"
+            },
+            Link = new ColumnLink()
+            {
+                Text = "Google",
+                Uri = new Uri("https://www.google.com")
+            },
+            Priority = new ColumnStatus()
+            {
+                Status = "High"
+            },
+            Status = new ColumnStatus()
+            {
+                Status = "Done"
+            },
+            Timeline = new ColumnTimeline()
+            {
+                From = new DateTime(2023, 11, 29),
+                To = new DateTime(2023, 12, 29)
+            },
+            Tags = new ColumnTag()
+            {
+                TagIds = [21057674, 21057675]
+            }
+        };
+
+        // Act
+        NET.Application.MondayResponse<Dictionary<string, Item>?>? mondayResponse = 
+            await this.MondayClient!.CreateBoardItemsAsync<TestRow>(this.BoardId, [testRow]);
+
+        // Attempt to get the item
+        NET.Application.MondayResponse<TestRow> item = await this.MondayClient!.GetBoardItemAsync<TestRow>(
+            mondayResponse.Response?.FirstOrDefault()?.Data?.FirstOrDefault().Value.Id ?? 0);
+
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsNull(mondayResponse.Errors);
+    }
+
+    [TestMethod]
     public async Task Cleanup()
     {
         // Get All Items
@@ -837,5 +916,13 @@ public class UnitTest1
 
         [MondayColumnHeader("rating")]
         public ColumnRating? Rating { get; set; }
+    }
+
+    public record Test2Row : MondayRow
+    {
+        [MondayColumnHeader("text0")]
+        public ColumnText? Text { get; set; }
+
+        public Group? Group { get; set; }
     }
 }

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -271,7 +271,7 @@ public class FunctionalTests
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("timeline").GetProperty("to").GetString() == "2023-12-29");
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("email").GetProperty("email").GetString() == "andreweberle@email.com.au");
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("email").GetProperty("text").GetString() == "hello world!");
-        Assert.IsTrue(jsonDocument.RootElement.GetProperty("rating").GetProperty("rating").GetInt32() == 5);
+        Assert.IsTrue(jsonDocument.RootElement.GetProperty("rating").GetProperty("rating").GetInt32() == 0);
     }
 
     [TestMethod]
@@ -833,12 +833,8 @@ public class FunctionalTests
         };
 
         // Act
-        NET.Application.MondayResponse<Dictionary<string, Item>?>? mondayResponse = 
+        NET.Application.MondayResponse<Dictionary<ulong, TestRow>?>? mondayResponse = 
             await this.MondayClient!.CreateBoardItemsAsync<TestRow>(this.BoardId, [testRow]);
-
-        // Attempt to get the item
-        NET.Application.MondayResponse<TestRow> item = await this.MondayClient!.GetBoardItemAsync<TestRow>(
-            mondayResponse.Response?.FirstOrDefault()?.Data?.FirstOrDefault().Value.Id ?? 0);
 
         // Assert
         Assert.IsTrue(mondayResponse.IsSuccessful);
@@ -846,7 +842,106 @@ public class FunctionalTests
     }
 
     [TestMethod]
-    public async Task Cleanup()
+    public async Task UpdateItemFromMondayRow_Should_Be_Ok()
+    {
+        // Arrange
+        TestRow testRow = new()
+        {
+            Name = new ColumnText()
+            {
+                Text = "Test Item 1"
+            },
+            Text = new ColumnText()
+            {
+                Text = "Andrew Eberle"
+            },
+            Number = new ColumnNumber()
+            {
+                Number = 10
+            },
+            Email = new ColumnEmail()
+            {
+                Email = "andrew.eberle@lithocraft.com.au"
+            },
+            Rating = new ColumnRating()
+            {
+                Rating = MondayRating.Five
+            },
+            Checkbox = new ColumnCheckBox()
+            {
+                IsChecked = true
+            },
+            Date = new ColumnDateTime()
+            {
+                Date = new DateTime(2023, 11, 29)
+            },
+            Dropdown = new ColumnDropDown()
+            {
+                Label = "Hello"
+            },
+            LongText = new ColumnLongText()
+            {
+                Text = "Hello, World!"
+            },
+            Link = new ColumnLink()
+            {
+                Text = "Google",
+                Uri = new Uri("https://www.google.com")
+            },
+            Priority = new ColumnStatus()
+            {
+                Status = "High"
+            },
+            Status = new ColumnStatus()
+            {
+                Status = "Done"
+            },
+            Timeline = new ColumnTimeline()
+            {
+                From = new DateTime(2023, 11, 29),
+                To = new DateTime(2023, 12, 29)
+            },
+            Tags = new ColumnTag()
+            {
+                TagIds = [21057674, 21057675]
+            }
+        };
+
+        // Act
+        NET.Application.MondayResponse<Dictionary<ulong, TestRow>?>? mondayResponse =
+            await this.MondayClient!.CreateBoardItemsAsync<TestRow>(this.BoardId, [testRow]);
+
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsNull(mondayResponse.Errors);
+
+        // Change The Text
+        testRow.Text.Text = null;
+        testRow.Status = null;
+        testRow.Priority = null;
+        testRow.Checkbox.IsChecked = false;
+        testRow.Number.Number = null;
+        testRow.Email.Email = null;
+        testRow.Link = null;
+        testRow.Dropdown = null;
+        testRow.Date = null;
+        testRow.LongText = null;
+        testRow.Timeline = null;
+        testRow.Tags = null;
+        testRow.Rating = null;
+        testRow.Name.Text = null;
+            
+        // Attempt To Update The Item.
+        mondayResponse = await this.MondayClient!.UpdateBoardItemAsync<TestRow>(this.BoardId, [testRow]);
+
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsNull(mondayResponse.Errors);
+    }
+
+
+    [TestMethod]
+    public async Task ZZZCleanup()
     {
         // Get All Items
         NET.Application.MondayResponse<TestRow> items = await this.MondayClient!.GetBoardItemsAsync<TestRow>(this.BoardId);


### PR DESCRIPTION
Users now have the ability to create / update a monday row by object providing it is inheriting the `MondayRow` record.
This is a much more smoother way of create/update instead of have to create an `Item` each time.

When an object is created, the row id will be assigned to it.

Column Type bug fixes applied.