### PR TITLE
Fix parsing email column data

### DIFF
--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnEmailType.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnEmailType.cs
@@ -3,6 +3,10 @@
 public record ColumnEmail : ColumnBaseType
 {
     public string? Email { get; set; }
+
+    /// <summary>
+    /// The email label disply text
+    /// </summary>
     public string? Message { get; set; }
 
     /// <summary>

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -229,7 +229,7 @@ public static partial class MondayUtilities
             case MondayColumnType.Email:
                 if (!string.IsNullOrEmpty(column.Text))
                 {
-                    string[] parts = column.Text.Split('-',
+                    string[] parts = column.Text.Split(" - ",
                         StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
                     return new ColumnEmail(column.Id, parts.LastOrDefault(), parts.FirstOrDefault());
                 }

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.26</Version>
+        <Version>1.0.27</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
While testing with the email object
`{ Email = "dev-user@test.com", Message = "display-text" }`

GraphQL query returns `Text = "display-text - dev-TEST@email.com"`
It then gets parsed into four items `[ "display", "text", "dev", "user@test.com" ]` which then gives the incorrect ColumnEmail value `{ Email = "user@test.com", Message = "display"}`

The correct split pattern is with spaces around the payload's hyphen: `" - "` instead of `"-"`