### PR TITLE
Add "updated_at" to Board entity.

### DIFF
--- a/src/MondaySharp.NET/Application/Entities/Board.cs
+++ b/src/MondaySharp.NET/Application/Entities/Board.cs
@@ -41,4 +41,7 @@ public record Board
     [JsonProperty("items_count")] public int ItemsCount { get; set; }
 
     [JsonProperty("items_page")] public ItemsPageByColumnValue? ItemsPage { get; set; }
+    
+    [JsonProperty("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
 }

--- a/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
+++ b/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
@@ -1645,7 +1645,7 @@ public partial class MondayClient : IMondayClient, IDisposable
 
         // Create The Response Parameters.
         const string RESPONSE_PARAMS =
-            @$"{{id name state board_kind board_folder_id description workspace_id item_terminology items_count permissions}}";
+            @$"{{id name state board_kind board_folder_id description workspace_id item_terminology items_count permissions updated_at}}";
 
         // Create parameters for the query
         StringBuilder parameters = new();

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.28</Version>
+        <Version>1.0.29</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 


### PR DESCRIPTION
We needed to detect if any new changes were made to the board, so "updated_at" can be used for this purpose. It was added directly to the Board, as it seems like a general purpose property.
https://developer.monday.com/api-reference/reference/boards#fields  
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e6e83658-f950-4cec-ae51-9ebded8815c6" />

Tested on the actual board.
<img width="989" alt="image" src="https://github.com/user-attachments/assets/dc2bc4ce-02f1-4864-859e-c536d07e2f22" />




