### PR TITLE
Issue #22 add people type

### DIFF
--- a/src/MondaySharp.NET/Application/Common/GetBoardItemResponse.cs
+++ b/src/MondaySharp.NET/Application/Common/GetBoardItemResponse.cs
@@ -3,18 +3,18 @@ using Newtonsoft.Json;
 
 namespace MondaySharp.NET.Application.Common;
 
-internal class GetBoardItemsByColumnValuesResponse
+internal sealed class GetBoardItemsByColumnValuesResponse
 {
     [JsonProperty("items_page_by_column_values")]
     public ItemsPageByColumnValue? ItemsPageByColumnValue { get; set; }
 }
 
-internal class NextItemsPageResponse
+internal sealed class NextItemsPageResponse
 {
     [JsonProperty("next_items_page")] public NextItemsPage? NextItemsPage { get; set; }
 }
 
-internal class NextItemsPage
+internal sealed class NextItemsPage
 {
     public string? Cursor { get; set; }
     public List<Item>? Items { get; set; }
@@ -26,12 +26,12 @@ internal class GetBoardItemsResponse
     [JsonProperty("boards")] public List<Board>? Boards { get; set; }
 }
 
-internal class GetBoardsResponse : GetBoardItemsResponse
+internal sealed class GetBoardsResponse : GetBoardItemsResponse
 {
 }
 
-public class ItemsPageByColumnValue
+public sealed class ItemsPageByColumnValue
 {
     public string? Cursor { get; set; }
-    public List<Item>? Items { get; set; }
+    public List<Item> Items { get; set; } = [];
 }

--- a/src/MondaySharp.NET/Application/Common/GetUsersColumnValuesResponse.cs
+++ b/src/MondaySharp.NET/Application/Common/GetUsersColumnValuesResponse.cs
@@ -1,0 +1,8 @@
+using MondaySharp.NET.Domain.Common;
+
+namespace MondaySharp.NET.Application.Common;
+
+internal sealed class GetUsersColumnValuesResponse
+{
+    public List<MondayUser>? Users { get; set; } = [];
+}

--- a/src/MondaySharp.NET/Application/Common/ItemBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Common/ItemBindableSource.cs
@@ -1,0 +1,18 @@
+using MondaySharp.NET.Application.Entities;
+using MondaySharp.NET.Application.Interfaces;
+using MondaySharp.NET.Domain.Common.Enums;
+
+namespace MondaySharp.NET.Application.Common;
+
+public sealed class ItemBindableSource(Item item) : IMondayBindableSource
+{
+    public ulong Id { get; } = item.Id;
+    public string? Name { get; } = item.Name;
+    public MondayState? State { get; } = item.State;
+    public Board? Board { get; } = item.Board;
+    public Group? Group { get; } = item.Group;
+    public IReadOnlyList<ColumnValue> ColumnValues { get; } = item.ColumnValues;
+    public IReadOnlyList<Asset> Assets { get; } = item.Assets;
+    public IReadOnlyList<Update> Updates { get; } = item.Updates;
+    public FileUpload? FileUpload { get; } = item.FileUpload;
+}

--- a/src/MondaySharp.NET/Application/Common/UserBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Common/UserBindableSource.cs
@@ -1,0 +1,19 @@
+using MondaySharp.NET.Application.Entities;
+using MondaySharp.NET.Application.Interfaces;
+using MondaySharp.NET.Domain.Common;
+using MondaySharp.NET.Domain.Common.Enums;
+
+namespace MondaySharp.NET.Application.Common;
+
+public sealed class UserBindableSource(MondayUser user) : IMondayBindableSource
+{
+    public ulong Id { get; } = user.Id;
+    public string? Name { get; } = user.Name;
+    public MondayState? State { get; } = null;
+    public Board? Board { get; } = null;
+    public Group? Group { get; } = null;
+    public IReadOnlyList<ColumnValue> ColumnValues { get; } = [];
+    public IReadOnlyList<Asset> Assets { get; } 
+    public IReadOnlyList<Update> Updates { get; }
+    public FileUpload? FileUpload { get; }
+}

--- a/src/MondaySharp.NET/Application/Entities/Asset.cs
+++ b/src/MondaySharp.NET/Application/Entities/Asset.cs
@@ -1,4 +1,5 @@
 ﻿using MondaySharp.NET.Application.JsonConverters;
+using MondaySharp.NET.Domain.Common;
 using Newtonsoft.Json;
 
 namespace MondaySharp.NET.Application.Entities;
@@ -25,7 +26,7 @@ public record Asset
 
     [JsonProperty("original_geometry")] public string? OriginalGeometry { get; set; }
 
-    [JsonProperty("uploaded_by")] public User? UploadedBy { get; set; }
+    [JsonProperty("uploaded_by")] public MondayUser? UploadedBy { get; set; }
 
     [JsonProperty("url")] public Uri? Url { get; set; }
 }

--- a/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
+++ b/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
@@ -17,5 +17,7 @@ public record ColumnValue
 
     [JsonProperty("__typename")] public string? TypeName { get; set; }
 
+    [JsonProperty("persons_and_teams")] public List<PeopleEntity> PeopleAndTeams { get; set; } = [];
+
     [JsonIgnore] public ColumnBaseType? ColumnBaseType { get; set; }
 }

--- a/src/MondaySharp.NET/Application/Entities/Group.cs
+++ b/src/MondaySharp.NET/Application/Entities/Group.cs
@@ -16,5 +16,5 @@ public record Group
 
     [JsonProperty("position")] public string? Position { get; set; }
 
-    [JsonProperty("items_page")] public List<Item>? Items { get; set; }
+    [JsonProperty("items_page")] public List<Item> Items { get; set; } = [];
 }

--- a/src/MondaySharp.NET/Application/Entities/Item.cs
+++ b/src/MondaySharp.NET/Application/Entities/Item.cs
@@ -8,7 +8,7 @@ public record Item
 {
     [JsonProperty("id")] public ulong Id { get; set; }
 
-    [JsonProperty("name")] public string? Name { get; set; }
+    [JsonProperty("name")] public string Name { get; set; }
 
     [JsonProperty("state")]
     [JsonConverter(typeof(StringEnumConverter))]
@@ -18,18 +18,11 @@ public record Item
 
     [JsonProperty("group")] public Group? Group { get; set; }
 
-    [JsonProperty("column_values")] public List<ColumnValue> ColumnValues { get; set; }
+    [JsonProperty("column_values")] public List<ColumnValue> ColumnValues { get; set; } = [];
 
-    [JsonProperty("assets")] public List<Asset> Assets { get; set; }
+    [JsonProperty("assets")] public List<Asset> Assets { get; set; } = [];
 
-    [JsonProperty("updates")] public List<Update> Updates { get; set; }
+    [JsonProperty("updates")] public List<Update> Updates { get; set; } = [];
 
     [JsonIgnore] public FileUpload? FileUpload { get; set; }
-
-    public Item()
-    {
-        ColumnValues = [];
-        Assets = [];
-        Updates = [];
-    }
 }

--- a/src/MondaySharp.NET/Application/Entities/PeopleEntity.cs
+++ b/src/MondaySharp.NET/Application/Entities/PeopleEntity.cs
@@ -1,0 +1,11 @@
+using MondaySharp.NET.Domain.Common.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace MondaySharp.NET.Application.Entities;
+
+public record PeopleEntity
+{
+    [JsonProperty("id")] public string? Id { get; set; }
+    [JsonProperty("kind")] [JsonConverter(typeof(StringEnumConverter))] public MondayPeopleEntityType Kind { get; set; }
+}

--- a/src/MondaySharp.NET/Application/Entities/User.cs
+++ b/src/MondaySharp.NET/Application/Entities/User.cs
@@ -1,5 +1,0 @@
-﻿namespace MondaySharp.NET.Application.Entities;
-
-public record User
-{
-}

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayBindableSource.cs
@@ -1,0 +1,22 @@
+using MondaySharp.NET.Application.Entities;
+using MondaySharp.NET.Domain.Common.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace MondaySharp.NET.Application.Interfaces;
+
+public interface IMondayBindableSource
+{
+    public ulong Id { get; }
+    public string? Name { get; }
+
+    [JsonProperty("state")] [JsonConverter(typeof(StringEnumConverter))] public MondayState? State { get; }
+    public Board? Board { get; }
+    public Group? Group { get; }
+
+    public IReadOnlyList<ColumnValue> ColumnValues { get; }
+    public IReadOnlyList<Asset> Assets { get; }
+    public IReadOnlyList<Update> Updates { get; }
+
+    public FileUpload? FileUpload { get; }
+}

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayClient.cs
@@ -49,5 +49,8 @@ public interface IMondayClient
     public Task<MondayResponse<T>> UpdateBoardItemsAsync<T>(ulong boardId, T[] items,
         CancellationToken cancellationToken = default) where T : MondayRow, new();
 
+    public Task<MondayResponse<T>> GetUsersAsync<T>(ulong[]? userIds = null, 
+        CancellationToken cancellationToken = default) where T : MondayUser, new();
+    
     public void Dispose();
 }

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayIdentity.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayIdentity.cs
@@ -1,0 +1,10 @@
+using System.Globalization;
+using MondaySharp.NET.Application.Attributes;
+
+namespace MondaySharp.NET.Application.Interfaces;
+
+public interface IMondayIdentity
+{
+    public ulong Id { get; set; }
+    public string? Name { get; set; }
+}

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnPeopleAndTeams.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnPeopleAndTeams.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using MondaySharp.NET.Domain.Common.Enums;
+
+namespace MondaySharp.NET.Domain.ColumnTypes;
+
+public sealed record PeopleAndTeamsEntry(MondayPeopleEntityType Kind, string? Text = null );
+
+public record ColumnPeopleAndTeams : ColumnBaseType
+{
+    public Dictionary<ulong, PeopleAndTeamsEntry> PeopleAndTeams { get; init; } = new();
+
+    public ColumnPeopleAndTeams(string? id = null, Dictionary<ulong, PeopleAndTeamsEntry>? peopleAndTeams = null)
+    {
+        Id = id;
+        if (peopleAndTeams is not null)
+            PeopleAndTeams = peopleAndTeams;
+    }
+
+    public ColumnPeopleAndTeams()
+    {
+    }
+
+    public ColumnPeopleAndTeams(string? id)
+    {
+        Id = id;
+    }
+    
+    public override string ToString()
+    {
+        if (string.IsNullOrWhiteSpace(Id))
+            throw new InvalidOperationException($"{nameof(ColumnPeopleAndTeams)} requires {nameof(Id)} to be set.");
+
+        if (PeopleAndTeams.Count == 0) return $"\"{Id}\": null";
+
+        var payload = new
+        {
+            personsAndTeams = PeopleAndTeams.Select(kv => new
+            {
+                id = kv.Key,
+                kind = kv.Value.Kind.ToString().ToLowerInvariant()
+            })
+        };
+
+        return $"\"{Id}\": {JsonSerializer.Serialize(payload)}";
+    }
+}
+

--- a/src/MondaySharp.NET/Domain/Common/Enums/MondayPeopleEntityType.cs
+++ b/src/MondaySharp.NET/Domain/Common/Enums/MondayPeopleEntityType.cs
@@ -1,0 +1,7 @@
+namespace MondaySharp.NET.Domain.Common.Enums;
+
+public enum MondayPeopleEntityType
+{
+    Person,
+    Team
+}

--- a/src/MondaySharp.NET/Domain/Common/MondayRow.cs
+++ b/src/MondaySharp.NET/Domain/Common/MondayRow.cs
@@ -1,9 +1,9 @@
 ﻿using MondaySharp.NET.Application.Attributes;
-using MondaySharp.NET.Domain.ColumnTypes;
+using MondaySharp.NET.Application.Interfaces;
 
 namespace MondaySharp.NET.Domain.Common;
 
-public record MondayRow
+public record MondayRow : IMondayIdentity
 {
     [MondayColumnHeader("id")] public ulong Id { get; set; }
 

--- a/src/MondaySharp.NET/Domain/Common/MondayUser.cs
+++ b/src/MondaySharp.NET/Domain/Common/MondayUser.cs
@@ -1,0 +1,10 @@
+using MondaySharp.NET.Application.Attributes;
+using MondaySharp.NET.Application.Interfaces;
+
+namespace MondaySharp.NET.Domain.Common;
+
+public record MondayUser : IMondayIdentity
+{
+    [MondayColumnHeader("id")] public ulong Id { get; set; }
+    [MondayColumnHeader("name")] public string? Name { get; set; }
+}

--- a/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
+++ b/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
@@ -81,16 +81,15 @@ public partial class MondayClient : IMondayClient, IDisposable
     /// <param name="disposing"></param>
     protected virtual void Dispose(bool disposing)
     {
-        if (!disposedValue && disposing)
-        {
-            _logger?.LogInformation("Disposing Monday Client.");
-            _graphQLHttpClient?.HttpClient?.Dispose();
+        if (disposedValue || !disposing) return;
+        
+        _logger?.LogInformation("Disposing Monday Client.");
+        _graphQLHttpClient?.HttpClient?.Dispose();
 
-            _logger?.LogInformation("Disposing GraphQL Client.");
-            _graphQLHttpClient?.Dispose();
+        _logger?.LogInformation("Disposing GraphQL Client.");
+        _graphQLHttpClient?.Dispose();
 
-            disposedValue = true;
-        }
+        disposedValue = true;
     }
 
     /// <summary>
@@ -158,8 +157,9 @@ public partial class MondayClient : IMondayClient, IDisposable
         }
 
         // Create New
-        StringBuilder stringBuilder = new();
-
+        StringBuilder itemsQueryStringBuilder = new();
+        StringBuilder columnValueFragments = new();
+        
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
@@ -167,7 +167,11 @@ public partial class MondayClient : IMondayClient, IDisposable
             if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
             {
                 // Append the query to the string builder.
-                stringBuilder.Append(query);
+                itemsQueryStringBuilder.Append(query);
+            }
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            {
+                columnValueFragments.Append(fragment);
             }
         }
 
@@ -186,8 +190,9 @@ public partial class MondayClient : IMondayClient, IDisposable
                     text
                     type
                     value
+                    {columnValueFragments}
                   }}
-                    {stringBuilder}
+                    {itemsQueryStringBuilder}
                 }}
               }}
             }}",
@@ -239,7 +244,7 @@ public partial class MondayClient : IMondayClient, IDisposable
                 T datanstance = Activator.CreateInstance<T>();
 
                 // Attempt To Bind The Items.
-                if (MondayUtilities.TryBindColumnDataAsync(columnPropertyMap!, item!, ref datanstance))
+                if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new ItemBindableSource(item), ref datanstance))
                 {
                     // Add the data to the response
                     mondayResponse.Response.Add(new MondayData<T>()
@@ -255,7 +260,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -302,8 +310,9 @@ public partial class MondayClient : IMondayClient, IDisposable
         }
 
         // Create New
-        StringBuilder stringBuilder = new();
-
+        StringBuilder itemsQueryStringBuilder = new();
+        StringBuilder columnValueFragments = new();
+        
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
@@ -311,7 +320,11 @@ public partial class MondayClient : IMondayClient, IDisposable
             if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
             {
                 // Append the query to the string builder.
-                stringBuilder.Append(query);
+                itemsQueryStringBuilder.Append(query);
+            }
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            {
+                columnValueFragments.Append(fragment);
             }
         }
 
@@ -328,8 +341,9 @@ public partial class MondayClient : IMondayClient, IDisposable
                   text
                   type
                   value
+                  {columnValueFragments}
                 }}
-                {stringBuilder}
+                {itemsQueryStringBuilder}
               }}
             }}",
             Variables = new
@@ -349,7 +363,10 @@ public partial class MondayClient : IMondayClient, IDisposable
             return new MondayResponse<T>()
             {
                 IsSuccessful = false,
-                Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+                Errors = MondayUtilities.BuildErrorMessages(
+                    graphQLResponse.Errors,
+                    graphQLResponse.Extensions
+                ).ToHashSet()
             };
         }
 
@@ -379,7 +396,7 @@ public partial class MondayClient : IMondayClient, IDisposable
             T dataInstance = Activator.CreateInstance<T>();
             
             // Attempt To Bind The Items.
-            if (MondayUtilities.TryBindColumnDataAsync(columnPropertyMap!, item!, ref dataInstance))
+            if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new ItemBindableSource(item), ref dataInstance))
             {
                 // Add the data to the response
                 mondayResponse.Response.Add(new MondayData<T>()
@@ -449,8 +466,9 @@ public partial class MondayClient : IMondayClient, IDisposable
         }
 
         // Create New
-        StringBuilder stringBuilder = new();
-
+        StringBuilder itemsQueryStringBuilder = new();
+        StringBuilder columnValueFragments = new();
+        
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
@@ -458,7 +476,11 @@ public partial class MondayClient : IMondayClient, IDisposable
             if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
             {
                 // Append the query to the string builder.
-                stringBuilder.Append(query);
+                itemsQueryStringBuilder.Append(query);
+            }
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            {
+                columnValueFragments.Append(fragment);
             }
         }
 
@@ -488,8 +510,9 @@ public partial class MondayClient : IMondayClient, IDisposable
                                 text
                                 type
                                 value
+                                {columnValueFragments}
                             }}
-                            {stringBuilder}
+                            {itemsQueryStringBuilder}
                         }}
                     }}
                 }}
@@ -540,7 +563,7 @@ public partial class MondayClient : IMondayClient, IDisposable
                 T dataInstance = Activator.CreateInstance<T>();
 
                 // Attempt To Bind The Items.
-                if (MondayUtilities.TryBindColumnDataAsync(columnPropertyMap!, item!, ref dataInstance))
+                if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new ItemBindableSource(item), ref dataInstance))
                 {
                     // Add the data to the response
                     mondayResponse.Response.Add(new MondayData<T>()
@@ -566,8 +589,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet(),
-            Response = null
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet(),
         };
     }
 
@@ -622,14 +647,18 @@ public partial class MondayClient : IMondayClient, IDisposable
             Group? group = null;
 
             // Foreach property in the item
-            foreach (PropertyInfo propertyInfo in item.value.GetType().GetProperties()
-                         .Where(x => x.GetCustomAttribute<MondayColumnTypeUnsupportedWriteAttribute>() == null))
+            foreach (PropertyInfo propertyInfo in item.value.GetType().GetProperties().Where(x => x.GetCustomAttribute<MondayColumnTypeUnsupportedWriteAttribute>() == null))
             {
-                // Skip the name property.
-                if (propertyInfo.Name == nameof(item.value.Name)) continue;
-
-                // Skip the id property.
-                if (propertyInfo.Name == nameof(item.value.Id)) continue;
+                // Check if the property is a MondayGroupType.
+                switch (propertyInfo.Name)
+                {
+                    // Skip the name property.
+                    case nameof(item.value.Name):
+                    
+                    // Skip the id property.
+                    case nameof(item.value.Id):
+                        continue;
+                }
 
                 // Check if the property is a MondayGroupType.
                 if (propertyInfo.PropertyType == typeof(Group))
@@ -645,36 +674,35 @@ public partial class MondayClient : IMondayClient, IDisposable
 
                     continue;
                 }
-
+                
                 // Check if the property is a ColumnBaseType
-                if (propertyInfo.PropertyType.IsSubclassOf(typeof(ColumnBaseType)))
+                if (!propertyInfo.PropertyType.IsSubclassOf(typeof(ColumnBaseType))) continue;
+                
+                // Get the column base type
+                ColumnBaseType? columnBaseType = (ColumnBaseType?)propertyInfo.GetValue(item.value);
+
+                // Check if the column base type is not null
+                if (columnBaseType is not null)
                 {
-                    // Get the column base type
-                    ColumnBaseType? columnBaseType = (ColumnBaseType?)propertyInfo.GetValue(item.value);
-
-                    // Check if the column base type is not null
-                    if (columnBaseType is not null)
+                    // Check there is an id.
+                    if (string.IsNullOrEmpty(columnBaseType.Id))
                     {
-                        // Check there is an id.
-                        if (string.IsNullOrEmpty(columnBaseType.Id))
+                        // Check if there is an attribute.
+                        if (propertyInfo.GetCustomAttribute<MondayColumnHeaderAttribute>() is not null)
                         {
-                            // Check if there is an attribute.
-                            if (propertyInfo.GetCustomAttribute<MondayColumnHeaderAttribute>() is not null)
-                            {
-                                // Set the id to the attribute id.
-                                columnBaseType.Id = propertyInfo.GetCustomAttribute<MondayColumnHeaderAttribute>()!
-                                    .ColumnId;
-                            }
-                            else
-                            {
-                                // Use the property name as the id.
-                                columnBaseType.Id = propertyInfo.Name;
-                            }
+                            // Set the id to the attribute id.
+                            columnBaseType.Id = propertyInfo.GetCustomAttribute<MondayColumnHeaderAttribute>()!
+                                .ColumnId;
                         }
-
-                        // Add the column base type to the list
-                        columnValues.Add(columnBaseType);
+                        else
+                        {
+                            // Use the property name as the id.
+                            columnBaseType.Id = propertyInfo.Name;
+                        }
                     }
+
+                    // Add the column base type to the list
+                    columnValues.Add(columnBaseType);
                 }
             }
 
@@ -726,7 +754,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -877,7 +908,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1032,7 +1066,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1155,7 +1192,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<Item>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1274,7 +1314,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<Item>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1342,8 +1385,9 @@ public partial class MondayClient : IMondayClient, IDisposable
         }
 
         // Create New
-        StringBuilder stringBuilder = new();
-
+        StringBuilder itemsQueryStringBuilder = new();
+        StringBuilder columnValueFragments = new();
+        
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
@@ -1351,7 +1395,11 @@ public partial class MondayClient : IMondayClient, IDisposable
             if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
             {
                 // Append the query to the string builder.
-                stringBuilder.Append(query);
+                itemsQueryStringBuilder.Append(query);
+            }
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            {
+                columnValueFragments.Append(fragment);
             }
         }
 
@@ -1370,8 +1418,9 @@ public partial class MondayClient : IMondayClient, IDisposable
                             text
                             type
                             value
+                            {columnValueFragments}
                         }}
-                        {stringBuilder}
+                        {itemsQueryStringBuilder}
                     }}
                 }}
             }}",
@@ -1417,7 +1466,7 @@ public partial class MondayClient : IMondayClient, IDisposable
                 T dataInstance = Activator.CreateInstance<T>();
 
                 // Attempt To Bind The Items.
-                if (MondayUtilities.TryBindColumnDataAsync(columnPropertyMap!, item!, ref dataInstance))
+                if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new ItemBindableSource(item), ref dataInstance))
                 {
                     mondayResponse.Response.Add(new MondayData<T>()
                     {
@@ -1432,7 +1481,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1535,7 +1587,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<Update>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1618,7 +1673,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<Item>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -1698,7 +1756,10 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<Board>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
     }
 
@@ -2041,8 +2102,9 @@ public partial class MondayClient : IMondayClient, IDisposable
         }
 
         // Create New
-        StringBuilder stringBuilder = new();
-
+        StringBuilder itemsQueryStringBuilder = new();
+        StringBuilder columnValueFragments = new();
+        
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
@@ -2050,7 +2112,11 @@ public partial class MondayClient : IMondayClient, IDisposable
             if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
             {
                 // Append the query to the string builder.
-                stringBuilder.Append(query);
+                itemsQueryStringBuilder.Append(query);
+            }
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            {
+                columnValueFragments.Append(fragment);
             }
         }
 
@@ -2067,8 +2133,9 @@ public partial class MondayClient : IMondayClient, IDisposable
                         text
                         type
                         value
+                        {columnValueFragments}
                     }}
-                    {stringBuilder}
+                    {itemsQueryStringBuilder}
                  }}
             }}",
             Variables = new
@@ -2094,7 +2161,7 @@ public partial class MondayClient : IMondayClient, IDisposable
                 T dataInstance = Activator.CreateInstance<T>();
 
                 // Attempt To Bind The Items.
-                if (MondayUtilities.TryBindColumnDataAsync(columnPropertyMap!, item, ref dataInstance))
+                if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new ItemBindableSource(item), ref dataInstance))
                 {
                     return new MondayResponse<T>()
                     {
@@ -2114,7 +2181,103 @@ public partial class MondayClient : IMondayClient, IDisposable
         return new MondayResponse<T>()
         {
             IsSuccessful = false,
-            Errors = graphQLResponse.Errors?.Select(x => x.Message).ToHashSet()
+            Errors = MondayUtilities.BuildErrorMessages(
+                graphQLResponse.Errors,
+                graphQLResponse.Extensions
+            ).ToHashSet()
         };
+    }
+    
+    public async Task<MondayResponse<T>> GetUsersAsync<T>(
+        ulong[]? userIds = null, CancellationToken cancellationToken = default) where T : MondayUser, new()
+    {
+        // If The GraphQL Client Is Null, Return Null.
+        if (_graphQLHttpClient == null)
+        {
+            return new MondayResponse<T>()
+            {
+                IsSuccessful = false,
+                Errors = ["GraphQL Client Is Null."]
+            };
+        }
+
+        // Create New Instance Of T Type.
+        T instance = Activator.CreateInstance<T>();
+        
+        // Create New
+        StringBuilder itemsQueryStringBuilder = new();
+        
+        // Get each property in instance.
+        foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
+        {
+            // Attempt to get the type from the GetItemsQueryBuilder
+            if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
+            {
+                // Append the query to the string builder.
+                itemsQueryStringBuilder.Append(query);
+            }
+        }
+                // Construct the GraphQL query
+        GraphQLRequest keyValuePairs = new()
+        {
+            Query = $@"query($userIds: [ID!]) {{
+                 users(ids: $userIds) {{
+                    id
+                    name
+                    {itemsQueryStringBuilder}
+                 }}
+            }}",
+            Variables = new
+            {
+                userIds = userIds is { Length: 0 } ? null : userIds
+            }
+        };
+
+        // Execute The Query.
+        GraphQLResponse<GetUsersColumnValuesResponse> graphQLResponse =
+            await _graphQLHttpClient.SendQueryAsync<GetUsersColumnValuesResponse>(keyValuePairs, cancellationToken);
+        
+        // Create The Response Parameters.
+        MondayResponse<T> mondayResponse = new MondayResponse<T>()
+        {
+            IsSuccessful = true,
+            Response = []
+        };
+
+        // If The Response Is Not Null, And The Data Is Not Null, And The Errors Is Null, Return The Data.
+        if (graphQLResponse.Errors is not null || !(graphQLResponse.Data?.Users?.Count > 0))
+        {
+            return mondayResponse with
+            {
+                IsSuccessful = false,
+                Errors = MondayUtilities.BuildErrorMessages(
+                    graphQLResponse.Errors,
+                    graphQLResponse.Extensions
+                ).ToHashSet()
+            };
+        }
+        
+        // Get The Column Property Map.
+        Dictionary<string, string> columnPropertyMap = MondayUtilities.GetColumnPropertyMap<T>();
+
+        // Loop through each item
+        foreach (MondayUser mondayUser in graphQLResponse.Data.Users)
+        {
+            // Create New Instance Of T Type.
+            T dataInstance = Activator.CreateInstance<T>();
+
+            // Attempt To Bind The Items.
+            if (MondayUtilities.TryBindColumnData(columnPropertyMap!, new UserBindableSource(mondayUser) , ref dataInstance))
+            {
+                // Add The Data To The Response.
+                mondayResponse.Response.Add(new MondayData<T>()
+                {
+                    Data = dataInstance
+                });
+            }
+        }
+            
+        // Return The Response.
+        return mondayResponse;
     }
 }

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -7,6 +7,8 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using GraphQL;
+using MondaySharp.NET.Application.Interfaces;
 
 namespace MondaySharp.NET.Infrastructure.Utilities;
 
@@ -28,7 +30,7 @@ public static partial class MondayUtilities
     {
         { typeof(Application.Entities.Group), @"group { id title color archived deleted position }" },
         { typeof(List<Asset>), @"assets { id name public_url url_thumbnail created_at }" },
-        { typeof(List<Update>), @"updates (limit: 100) { id text_body }" }
+        { typeof(List<Update>), @"updates (limit: 100) { id text_body }" },
     };
 
     // Define the supported types and their corresponding error messages
@@ -38,6 +40,22 @@ public static partial class MondayUtilities
         { typeof(List<Asset>), "Multiple Asset Properties Are Not Supported." },
         { typeof(List<Update>), "Multiple Update Properties Are Not Supported." }
     };
+    
+    // https://developer.monday.com/api-reference/reference/column-values-v2#using-fragments-to-get-column-specific-fields
+    public static readonly Dictionary<Type, string> ColumnValueFragments = new()
+    {
+        {
+            typeof(ColumnPeopleAndTeams),
+            """
+            ... on PeopleValue {
+                persons_and_teams {
+                    id
+                    kind
+                }
+            }
+            """
+        }
+    };
 
     /// <summary>
     /// 
@@ -46,40 +64,55 @@ public static partial class MondayUtilities
     /// <param name="item"></param>
     /// <param name="destination"></param>
     /// <returns></returns>
-    public static bool TryBindColumnDataAsync<T>(
-        Dictionary<string, string> columnPropertyMap, Item item, ref T destination) where T : MondayRow, new()
+    public static bool TryBindColumnData<T>(
+        IReadOnlyDictionary<string, string> columnPropertyMap,
+        IMondayBindableSource source,
+        ref T destination)
+        where T : IMondayIdentity, new()
     {
-        // Get The Destination Type.
-        Type? destinationType = destination?.GetType();
+        destination.Id = source.Id;
+        destination.Name = source.Name;
 
-        // If The Destination Type Is Null, Return False.
-        if (destinationType == null || destination == null) return false;
+        Type destinationType = destination.GetType();
 
-        // Assign Default Values.
-        destination.Id = item.Id;
-        destination.Name = item.Name;
+        SetPropertyIfExists(destinationType, "Group", source.Group, destination);
+        SetPropertyIfExists(destinationType, "Assets", source.Assets, destination);
+        SetPropertyIfExists(destinationType, "Updates", source.Updates, destination);
 
-        SetPropertyIfExists(destinationType, nameof(item.Group), item.Group, destination);
-        SetPropertyIfExists(destinationType, nameof(item.Assets), item.Assets, destination);
-        SetPropertyIfExists(destinationType, nameof(item.Updates), item.Updates, destination);
-
-        foreach (ColumnValue? columnValue in item.ColumnValues
-                     .Where(x => x.Type != MondayColumnType.Subtasks))
+        foreach (ColumnValue columnValue in source.ColumnValues.Where(x => x.Type != MondayColumnType.Subtasks))
         {
-            // Perform dictionary lookup once
-            string columnId = columnValue.Id ?? string.Empty;
-            if (columnPropertyMap.TryGetValue(columnId, out string? propertyName) ||
-                columnPropertyMap.TryGetValue(char.ToUpper(columnId[0], Culture) + columnId[1..], out propertyName) ||
-                columnId.Replace(" ", "") == propertyName)
-            {
-                if (string.IsNullOrEmpty(propertyName)) continue;
+            string? rawId = columnValue.Id;
+            if (string.IsNullOrWhiteSpace(rawId)) continue;
 
-                PropertyInfo? property = destinationType.GetProperty(propertyName);
-                property?.SetValue(destination, CreateColumnTypeInstance(columnValue.Type, columnValue));
-            }
+            // normalize variants once
+            string noSpaces = rawId.Replace(" ", "");
+            string pascal = rawId.Length == 0 ? rawId : char.ToUpper(rawId[0], Culture) + rawId[1..];
+
+            if (!TryResolvePropertyName(columnPropertyMap, rawId, pascal, noSpaces, out string? propertyName)) continue;
+            if (string.IsNullOrWhiteSpace(propertyName)) continue;
+
+            PropertyInfo? prop = destinationType.GetProperty(propertyName);
+            if (prop == null || !prop.CanWrite) continue;
+
+            prop.SetValue(destination, CreateColumnTypeInstance(columnValue.Type, columnValue));
         }
 
         return true;
+    }
+    
+    private static bool TryResolvePropertyName(
+        IReadOnlyDictionary<string, string> map,
+        string rawId,
+        string pascalId,
+        string noSpacesId,
+        out string? propertyName)
+    {
+        if (map.TryGetValue(rawId, out propertyName)) return true;
+        if (map.TryGetValue(pascalId, out propertyName)) return true;
+        if (map.TryGetValue(noSpacesId, out propertyName)) return true;
+
+        propertyName = null;
+        return false;
     }
 
     /// <summary>
@@ -260,7 +293,58 @@ public static partial class MondayUtilities
 
                 // Return the Column Rating.
                 return new ColumnRating(column.Id, rating);
+            
+            case MondayColumnType.People:
+            {
+                if (string.IsNullOrEmpty(column.Text))
+                {
+                    return new ColumnPeopleAndTeams(column.Id, []);
+                }
 
+                // Split and clean the display values
+                string[] displayValues = column.Text
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(v => v.Trim())
+                    .ToArray();
+
+                // Get the structured entities
+                IEnumerable<PeopleEntity> entities = column.PeopleAndTeams;
+
+                // Critical safety check: lengths must match
+                if (displayValues.Length != entities.Count())
+                {
+                    throw new InvalidOperationException(
+                        $"Mismatch between people display names ({displayValues.Length}) and entities ({entities.Count()}) " +
+                        $"in column '{column.Id}'. Data may be corrupted or API changed.");
+                }
+
+                // Create the dictionary of people and teams
+                Dictionary<ulong, PeopleAndTeamsEntry> peopleAndTeams = [];
+
+                // Loop through the entities and create the dictionary
+                for (int i = 0; i < displayValues.Length; i++)
+                {
+                    // Attempt to get the entity by index
+                    PeopleEntity entity = entities.ElementAt(i);
+                    
+                    // Assign the display name to the entity
+                    string displayName = displayValues[i];
+
+                    // Attempt to parse the person ID
+                    if (!ulong.TryParse(entity.Id, out ulong personId))
+                    {
+                        // This should rarely happen if API is consistent, but still guard
+                        throw new ArgumentException($"Invalid person ID '{entity.Id}' at position {i}: '{displayName}'");
+                    }
+
+                    // Add the entity to the dictionary
+                    peopleAndTeams[personId] = new PeopleAndTeamsEntry(entity.Kind, displayName);
+                }
+
+                // Return the column people and teams
+                return new ColumnPeopleAndTeams(column.Id, peopleAndTeams);
+            }
+            
             default:
                 throw new ArgumentException($"Unsupported column type: {columnType}");
         }
@@ -273,8 +357,7 @@ public static partial class MondayUtilities
     /// <returns></returns>
     public static string ToColumnValuesJson(this List<ColumnBaseType>? columnTypes)
     {
-        if (columnTypes == null) return string.Empty;
-        if (columnTypes.Count == 0) return string.Empty;
+        if (columnTypes == null || columnTypes.Count == 0) return string.Empty;
 
         // Get the total count of all column types.
         int totalCount = columnTypes.Sum(GetColumnTypeLength);
@@ -298,23 +381,22 @@ public static partial class MondayUtilities
         for (int i = 0; i < columnTypesSpan.Length; i++)
         {
             // If the column type is not null, add it to the json string.
-            if (columnTypesSpan[i] != null)
+            if (columnTypesSpan[i] == null) continue;
+            
+            // ToString will have an override that will return the correct JSON format.
+            string columnTypeString = columnTypesSpan[i].ToString();
+
+            // Copy the string to the jsonChars span.
+            columnTypeString.AsSpan().CopyTo(jsonChars[currentIndex..]);
+
+            // Increment the current index by the length of the column type string.
+            currentIndex += columnTypeString.Length;
+
+            // If the current index is less than the column types span length - 1, add a comma.
+            if (i < columnTypesSpan.Length - 1)
             {
-                // ToString will have an override that will return the correct JSON format.
-                string columnTypeString = columnTypesSpan[i].ToString();
-
-                // Copy the string to the jsonChars span.
-                columnTypeString.AsSpan().CopyTo(jsonChars[currentIndex..]);
-
-                // Increment the current index by the length of the column type string.
-                currentIndex += columnTypeString.Length;
-
-                // If the current index is less than the column types span length - 1, add a comma.
-                if (i < columnTypesSpan.Length - 1)
-                {
-                    // Add a comma.
-                    jsonChars[currentIndex++] = ',';
-                }
+                // Add a comma.
+                jsonChars[currentIndex++] = ',';
             }
         }
 
@@ -328,10 +410,8 @@ public static partial class MondayUtilities
         jsonString = jsonString.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
         // If the json string is not valid, throw an exception.
-        if (!IsValidJson(jsonString)) throw new JsonException("Invalid JSON format!");
-
-        // Return the json string.
-        return jsonString;
+        return !IsValidJson(jsonString) ? throw new JsonException("Invalid JSON format!") 
+            : jsonString;
     }
 
     /// <summary>
@@ -366,6 +446,39 @@ public static partial class MondayUtilities
         catch (JsonException)
         {
             return false;
+        }
+    }
+    
+    public static IEnumerable<string> BuildErrorMessages(
+        IEnumerable<GraphQLError>? errors,
+        IReadOnlyDictionary<string, object>? extensions)
+    {
+        if (errors is null)
+            yield break;
+
+        foreach (GraphQLError error in errors)
+        {
+            // Base message
+            if (!string.IsNullOrWhiteSpace(error.Message)) yield return error.Message;
+
+            // Try to extract Monday specific error details.
+            if (error.Extensions is not null &&
+                error.Extensions.TryGetValue("error_data", out object? errorDataObj) &&
+                errorDataObj is IDictionary<string, object> errorData)
+            {
+                if (errorData.TryGetValue("column_id", out object? columnId))
+                    yield return $"Invalid column ID: '{columnId}'";
+
+                if (errorData.TryGetValue("error_reason", out object? reason))
+                    yield return $"Reason: {reason}";
+            }
+
+            // Optional: request id (useful for support/debugging)
+            if (extensions != null &&
+                extensions.TryGetValue("request_id", out object? requestId))
+            {
+                yield return $"Request ID: {requestId}";
+            }
         }
     }
 }

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.29</Version>
+        <Version>1.0.30</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -59,7 +59,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -85,7 +85,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "FROM UNIT TEST"
                     }
                 },
@@ -120,7 +120,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -131,6 +131,7 @@ public class FunctionalTests
 
         // Assert
         Assert.IsTrue(items.Response?.Count > 0);
+        Assert.IsTrue(items.Response?.FirstOrDefault()?.Data?.Group?.Id == "new_group53864");
     }
 
     [TestMethod]
@@ -141,7 +142,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -153,7 +154,7 @@ public class FunctionalTests
                 Name = "Test Item 1",
                 Text = new ColumnText()
                 {
-                    Id = "text_mkmn7km4",
+                    Id = "text0",
                     Text = "FROM UNIT TEST"
                 }
             }
@@ -179,7 +180,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "FROM UNIT TEST"
                     }
                 }
@@ -196,7 +197,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             },
         ];
@@ -223,9 +224,9 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "Andrew Eberle"
-                    }
+                    },
                 },
             ]
         };
@@ -250,7 +251,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -296,10 +297,22 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "Andrew Eberle"
-                    }
+                    },
                 },
+                new ColumnValue()
+                {
+                    ColumnBaseType = new ColumnPeopleAndTeams()
+                    {
+                        Id = "multiple_person_mkz16gmv",
+                        PeopleAndTeams = new Dictionary<ulong, PeopleAndTeamsEntry>()
+                        {
+                            { 12254632, new PeopleAndTeamsEntry(MondayPeopleEntityType.Person) },
+                            { 27015209, new PeopleAndTeamsEntry(MondayPeopleEntityType.Person) }
+                        }
+                    }
+                }
             ]
         };
 
@@ -400,7 +413,7 @@ public class FunctionalTests
             new()
             {
                 Name = "Test Item 1",
-                Group = new Group() { Id = "topics" },
+                Group = new Group() { Id = "new_group53864" },
                 ColumnValues =
                 [
                     new ColumnValue()
@@ -432,7 +445,7 @@ public class FunctionalTests
             new()
             {
                 Name = "Test Item 2",
-                Group = new Group() { Id = "topics" },
+                Group = new Group() { Id = "new_group53864" },
                 ColumnValues =
                 [
                     new ColumnValue()
@@ -475,6 +488,17 @@ public class FunctionalTests
                             Id = "contact_phone",
                             Phone = "1234567890"
                         }
+                    },
+                    new ColumnValue()
+                    {
+                        ColumnBaseType = new ColumnPeopleAndTeams()
+                        {
+                            Id = "multiple_person_mkz16gmv",
+                            PeopleAndTeams = new Dictionary<ulong, PeopleAndTeamsEntry>()
+                            {
+                                { 12254632, new PeopleAndTeamsEntry(MondayPeopleEntityType.Person) }
+                            }
+                        }
                     }
                 ]
             }
@@ -506,7 +530,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -561,7 +585,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "FROM UNIT TEST"
                     }
                 },
@@ -595,7 +619,7 @@ public class FunctionalTests
         Item item = new()
         {
             Name = "Test Item 1",
-            Group = new Group() { Id = "topics" },
+            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
@@ -619,7 +643,7 @@ public class FunctionalTests
         Item item2 = new()
         {
             Name = "Test Item 2",
-            Group = new Group() { Id = "topics" },
+            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
@@ -701,7 +725,7 @@ public class FunctionalTests
         Item item = new()
         {
             Name = "Test Item 1",
-            Group = new Group() { Id = "topics" },
+            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
@@ -725,7 +749,7 @@ public class FunctionalTests
         Item item1 = new()
         {
             Name = "Test Item 2",
-            Group = new Group() { Id = "topics" },
+            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
@@ -767,13 +791,13 @@ public class FunctionalTests
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "file_mkp0y7rx"
+            ColumnId = "files4"
         };
         FileUpload fileUpload1 = new()
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "file_mkp0y7rx"
+            ColumnId = "files4"
         };
 
         item.FileUpload = fileUpload;
@@ -950,7 +974,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "Complete"
+                Status = "Done"
             },
             Timeline = new ColumnTimeline()
             {
@@ -965,6 +989,13 @@ public class FunctionalTests
             {
                 Phone = "1234567890",
                 CountryShortName = "US"
+            },
+            Person1 = new ColumnPeopleAndTeams()
+            {
+                PeopleAndTeams = new Dictionary<ulong, PeopleAndTeamsEntry>()
+                {
+                    { 12254632, new PeopleAndTeamsEntry(MondayPeopleEntityType.Person) } 
+                }
             }
         };
 
@@ -1029,7 +1060,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "Complete"
+                Status = "Done"
             },
             Timeline = new ColumnTimeline()
             {
@@ -1044,6 +1075,13 @@ public class FunctionalTests
             {
                 Phone = "1234567890",
                 CountryShortName = "US"
+            },
+            Person1 = new ColumnPeopleAndTeams()
+            {
+                PeopleAndTeams = new Dictionary<ulong, PeopleAndTeamsEntry>()
+                {
+                    { 12254632, new PeopleAndTeamsEntry(MondayPeopleEntityType.Person) } 
+                }
             }
         };
 
@@ -1072,10 +1110,11 @@ public class FunctionalTests
         testRow.Rating = null;
         testRow.Name = "Updated Item";
         testRow.Phone = null;
+        testRow.Person1 = null;
 
         // Attempt To Update The Item.
         mondayResponse = await MondayClient!.UpdateBoardItemsAsync<TestRow>(BoardId, [testRow]);
-
+        
         // Assert
         Assert.IsTrue(mondayResponse.IsSuccessful);
         Assert.IsTrue(mondayResponse.Response?.All(x => x.Data?.Id != 0));
@@ -1133,7 +1172,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "Complete"
+                Status = "In Testing"
             },
             Timeline = new ColumnTimeline()
             {
@@ -1208,8 +1247,6 @@ public class FunctionalTests
         Assert.IsTrue(mondayResponseSubRow.Response?.Count == 2);
         Assert.IsTrue(mondayResponseSubRow.Response?.FirstOrDefault()?.Data?.Name == testSubRow0.Name);
         Assert.IsTrue(mondayResponseSubRow.Response?.LastOrDefault()?.Data?.Name == testSubRow1.Name);
-        Assert.IsTrue(mondayResponseSubRow.Response?.LastOrDefault()?.Data?.Id >
-                      mondayResponseSubRow.Response?.FirstOrDefault()?.Data?.Id);
         Assert.IsNull(mondayResponseSubRow.Errors);
     }
 
@@ -1327,8 +1364,6 @@ public class FunctionalTests
         Assert.IsTrue(mondayResponseSubItem.Response?.Count == 2);
         Assert.IsTrue(mondayResponseSubItem.Response?.FirstOrDefault()?.Data?.Name == subItem1.Name);
         Assert.IsTrue(mondayResponseSubItem.Response?.LastOrDefault()?.Data?.Name == subItem2.Name);
-        Assert.IsTrue(mondayResponseSubItem.Response?.LastOrDefault()?.Data?.Id >
-                      mondayResponseSubItem.Response?.FirstOrDefault()?.Data?.Id);
         Assert.IsNull(mondayResponseSubItem.Errors);
     }
 
@@ -1361,7 +1396,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text_mkmn7km4",
+                        Id = "text0",
                         Text = "FROM UNIT TEST"
                     }
                 }
@@ -1390,7 +1425,7 @@ public class FunctionalTests
             Name = "Test Item Create",
             Text = new ColumnText()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             }
         };
@@ -1416,7 +1451,7 @@ public class FunctionalTests
             Name = "Test Item Update Details For Issue 10",
             Group = new Group()
             {
-                Id = "topics"
+                Id = "new_group53864"
             },
             Text = new ColumnText()
             {
@@ -1471,7 +1506,7 @@ public class FunctionalTests
             Name = "Test Item Update Details For Issue 9",
             Group = new Group()
             {
-                Id = "topics"
+                Id = "new_group53864"
             },
             Text = new ColumnText()
             {
@@ -1580,7 +1615,7 @@ public class FunctionalTests
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "file_mkp0y7rx"
+            ColumnId = "files4"
         };
 
         item.FileUpload = fileUpload;
@@ -1726,7 +1761,7 @@ public class FunctionalTests
             Name = "Test Item Create",
             XeroId = new ColumnText()
             {
-                Id = "text_mkmn7km4",
+                Id = "text0",
                 Text = "FROM UNIT TEST"
             }
         };
@@ -1760,9 +1795,41 @@ public class FunctionalTests
         Assert.IsTrue(updatedItem.Response?.FirstOrDefault()?.Data?.Name == item.Data.Name);
         Assert.IsNull(updatedItem.Errors);
     }
+
+    [TestMethod]
+    public async Task Get_People_Should_Be_Ok()
+    {
+        // Act
+        NET.Application.MondayResponse<User> mondayResponse =
+            await MondayClient!.GetUsersAsync<User>([]);
+        
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsTrue(mondayResponse.Response?.Count > 0);
+    }
+    
+    [TestMethod]
+    public async Task Get_Person_Should_Be_Ok()
+    {
+        // Act
+        NET.Application.MondayResponse<User> mondayResponse =
+            await MondayClient!.GetUsersAsync<User>([12254632]);
+        
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsTrue(mondayResponse.Response?.Count == 1);
+        Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Id == 12254632);
+        Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Name == "Andrew Eberle");
+    }
+    
+    public record User : MondayUser
+    {
+        
+    }
+    
     public record Customer : MondayRow
     {
-        [MondayColumnHeader("text_mkmn7km4")]
+        [MondayColumnHeader("text0")]
         public ColumnText? XeroId { get; set; }
     }
     
@@ -1811,7 +1878,9 @@ public class FunctionalTests
 
         [MondayColumnHeader("rating")] public ColumnRating? Rating { get; set; }
 
-        [MondayColumnHeader("phone")] public ColumnPhone? Phone { get; set; }
+        [MondayColumnHeader("phone_mknbw0n6")] public ColumnPhone? Phone { get; set; }
+        [MondayColumnHeader("multiple_person_mkz16gmv")] public ColumnPeopleAndTeams? Person0 { get; set; }
+        [MondayColumnHeader("multiple_person_mkz17a7w")] public ColumnPeopleAndTeams? Person1 { get; set; }
     }
 
     public record Test2Row : MondayRow
@@ -1823,11 +1892,11 @@ public class FunctionalTests
 
     public record TestSubRow : MondayRow
     {
-        [MondayColumnHeader("status")] public ColumnStatus? Status { get; set; }
+        [MondayColumnHeader("color_mkz1z6k6")] public ColumnStatus? Status { get; set; }
 
-        [MondayColumnHeader("date0")] public ColumnDateTime? DueDate { get; set; }
+        [MondayColumnHeader("date6")] public ColumnDateTime? DueDate { get; set; }
 
-        [MondayColumnHeader("numeric_mkp05akm")] public ColumnNumber? Priority { get; set; }
+        [MondayColumnHeader("numbers8")] public ColumnNumber? Priority { get; set; }
     }
 
     // Fields currently on Test-Board
@@ -1837,12 +1906,12 @@ public class FunctionalTests
 
         [MondayColumnHeader("status")] public ColumnStatus? Status { get; set; }
 
-        [MondayColumnHeader("date_mkp02cdj")] public ColumnDateTime? Date { get; set; }
+        [MondayColumnHeader("date")] public ColumnDateTime? Date { get; set; }
 
-        [MondayColumnHeader("dropdown_mkp0raj0")] public ColumnDropDown? Dropdown { get; set; }
+        [MondayColumnHeader("dropdown")] public ColumnDropDown? Dropdown { get; set; }
 
-        [MondayColumnHeader("text_mkmn7km4")] public ColumnText? Text { get; set; }
+        [MondayColumnHeader("text0")] public ColumnText? Text { get; set; }
 
-        [MondayColumnHeader("file_mkp0y7rx")] public ColumnFile? Files { get; set; }
+        [MondayColumnHeader("files4")] public ColumnFile? Files { get; set; }
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the MondaySharp.NET library, focusing on enhanced support for people and teams columns, improved type safety, and better error handling. The changes include new and updated domain models, interface refinements, and updates to the persistence layer to support more robust data binding and GraphQL query construction.

**Support for People and Teams Columns:**
- Added a new `PeopleEntity` record and related enum `MondayPeopleEntityType` to represent persons and teams, along with a new column type `ColumnPeopleAndTeams` for handling people and teams columns.
- Updated the `ColumnValue` record to include a `PeopleAndTeams` property, enabling the storage of people and teams data directly on column values.

**Type Safety and Domain Model Enhancements:**
- Made several classes and records sealed and initialized collection properties with empty lists to ensure immutability and prevent null reference issues (e.g., `Item`, `Group`, `ItemsPageByColumnValue`, etc.).
- Changed the `name` property in the `Item` record from nullable to non-nullable, enforcing the presence of a name. 
- Replaced usage of the old `User` class with the new `MondayUser` record throughout the codebase for consistency. 

**Interface and Bindable Source Improvements:**
- Introduced the `IMondayIdentity` and `IMondayBindableSource` interfaces to standardize identity and data binding for entities, and created new bindable source classes for items and users.
- Updated the `MondayRow` and `MondayUser` records to implement `IMondayIdentity`.

**Persistence Layer and Query Construction:**
- Refactored the GraphQL query construction in `MondayClient` to use separate string builders for item queries and column value fragments, allowing for more flexible and extensible queries.
- Improved error handling by using a utility method to build error messages from both GraphQL errors and extensions. 
- Enhanced the data binding process to use the new `ItemBindableSource` for more reliable property mapping.

**API Enhancements:**
- Added a new method to `IMondayClient` for fetching users and a corresponding response class for user column values. 

These changes collectively improve the maintainability, safety, and extensibility of the MondaySharp.NET library, especially for scenarios involving people and teams columns and advanced data binding.

---

**People and Teams Column Support**
- Added `PeopleEntity` record and `MondayPeopleEntityType` enum to represent persons and teams entities.
- Introduced `ColumnPeopleAndTeams` column type and updated `ColumnValue` to include a `PeopleAndTeams` property.

**Column Fragments Added**
- Add `PeopleValues` fragments added
- TODO: Add remaining as seen in https://developer.monday.com/api-reference/reference/column-values-v2#using-fragments-to-get-column-specific-fields

**Type Safety and Domain Model Updates**
- Sealed key classes/records and initialized collection properties to empty lists for null-safety (e.g., `Item`, `Group`, `ItemsPageByColumnValue`).
- Changed `Item.Name` to be non-nullable.
- Replaced old `User` class with new `MondayUser` record and updated references.

**Interfaces and Bindable Sources**
- Added `IMondayIdentity` and `IMondayBindableSource` interfaces for standardization.
- Created `ItemBindableSource` and `UserBindableSource` classes for improved data binding.
- Updated `MondayRow` and `MondayUser` to implement `IMondayIdentity`.

**Persistence and Query Construction**
- Refactored query construction in `MondayClient` to separate item queries and column value fragments.
- Improved error handling by aggregating error messages from multiple sources.
- Updated data binding to use `ItemBindableSource`. 

**API Enhancements**
- Added `GetUsersAsync` method to `IMondayClient` and a new response class for user column values.