### PR TITLE
Mirror columns implementation

### DIFF
--- a/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
+++ b/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
@@ -19,5 +19,7 @@ public record ColumnValue
 
     [JsonProperty("persons_and_teams")] public List<PeopleEntity> PeopleAndTeams { get; set; } = [];
 
+    [JsonProperty("mirrored_items")] public List<MirrorItem> MirroredItems { get; set; } = [];
+
     [JsonIgnore] public ColumnBaseType? ColumnBaseType { get; set; }
 }

--- a/src/MondaySharp.NET/Application/Entities/MirrorItem.cs
+++ b/src/MondaySharp.NET/Application/Entities/MirrorItem.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
+
+namespace MondaySharp.NET.Application.Entities;
+
+public class MirrorItem
+{
+    [JsonProperty("mirrored_value")]
+    public ColumnValue? MirroredValue { get; set; }
+}

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnMirror.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnMirror.cs
@@ -1,0 +1,12 @@
+﻿namespace MondaySharp.NET.Domain.ColumnTypes;
+
+public record ColumnMirror<T> : ColumnBaseType where T : ColumnBaseType
+{
+    public List<T> Items { get; set; } = [];
+    public ColumnMirror(string? id, List<T> values)
+    {
+        Id = id;
+        Items = values;
+    }
+    public ColumnMirror() {}
+}

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -440,15 +440,16 @@ public static partial class MondayUtilities
                 // Get the first mirrored item to determine the type of the mirror column
                 MirrorItem? firstMirrorItem = column.MirroredItems.FirstOrDefault();
 
+                // If the first mirrored item is null or has a null mirrored value, throw an exception as we cannot determine the mirror column type
+                if (firstMirrorItem?.MirroredValue == null)
+                {
+                    throw new InvalidOperationException($"The first mirrored item in column '{column.Id}' has a null mirrored value, cannot determine mirror column type.");
+                }
+
                 // Check all mirrored items to ensure they are of the same type, if not throw an exception
                 if (column.MirroredItems.Any(item => item.MirroredValue?.GetType() != firstMirrorItem?.MirroredValue?.GetType()))
                 {
                     throw new InvalidOperationException($"Inconsistent mirrored value types in column '{column.Id}'. All mirrored items must be of the same type.");
-                }
-
-                if (firstMirrorItem?.MirroredValue == null)
-                {
-                    throw new InvalidOperationException($"The first mirrored item in column '{column.Id}' has a null mirrored value, cannot determine mirror column type.");
                 }
 
                 if (!SupportedMirrorColumnTypes.TryGetValue(firstMirrorItem.MirroredValue.Type, out Type? mirrorColumnType))
@@ -488,7 +489,7 @@ public static partial class MondayUtilities
                 Type mirrorColumnInstanceType = typeof(ColumnMirror<>).MakeGenericType([mirrorColumnType]);
 
                 // Create the mirror column instance
-                var mirrorColumnInstance = Activator.CreateInstance(mirrorColumnInstanceType, column.Id, list) 
+                object mirrorColumnInstance = Activator.CreateInstance(mirrorColumnInstanceType, column.Id, list)
                     ?? throw new InvalidOperationException($"Failed to create mirror column instance for type {mirrorColumnInstanceType}");
 
                 return mirrorColumnInstance;

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using GraphQL;
 using MondaySharp.NET.Application.Interfaces;
+using System.Collections;
 
 namespace MondaySharp.NET.Infrastructure.Utilities;
 
@@ -40,7 +41,26 @@ public static partial class MondayUtilities
         { typeof(List<Asset>), "Multiple Asset Properties Are Not Supported." },
         { typeof(List<Update>), "Multiple Update Properties Are Not Supported." }
     };
-    
+
+    public static readonly Dictionary<MondayColumnType, Type> SupportedMirrorColumnTypes = new()
+    {
+        { MondayColumnType.Text, typeof(ColumnText) },
+        { MondayColumnType.Numbers, typeof(ColumnNumber) },
+        { MondayColumnType.Status, typeof(ColumnStatus) },
+        { MondayColumnType.Date, typeof(ColumnDateTime) },
+        { MondayColumnType.Checkbox, typeof(ColumnCheckBox) },
+        { MondayColumnType.Color_Picker, typeof(ColumnColorPicker) },
+        { MondayColumnType.Email, typeof(ColumnEmail) },
+        { MondayColumnType.Dropdown, typeof(ColumnDropDown) },
+        { MondayColumnType.Link , typeof(ColumnLink) },
+        { MondayColumnType.Long_Text , typeof(ColumnLongText) },
+        { MondayColumnType.People , typeof(ColumnPeopleAndTeams) },
+        { MondayColumnType.Phone , typeof(ColumnPhone) },
+        { MondayColumnType.Rating , typeof(ColumnRating) },
+        { MondayColumnType.Tags , typeof(ColumnTag) },
+        { MondayColumnType.Timeline , typeof(ColumnTimeline) }
+    };
+
     // https://developer.monday.com/api-reference/reference/column-values-v2#using-fragments-to-get-column-specific-fields
     public static readonly Dictionary<Type, string> ColumnValueFragments = new()
     {
@@ -54,7 +74,79 @@ public static partial class MondayUtilities
                 }
             }
             """
-        }
+        },
+        
+        {
+            typeof(ColumnMirror<ColumnText>),
+            """
+            ... on MirrorValue {
+                    mirrored_items {
+                        mirrored_value {
+                            ... on TextValue {
+                                id
+                                type,
+                                value
+                                text
+                            }
+                    }
+                }
+            }
+            """
+        },
+
+        {
+            typeof(ColumnMirror<ColumnNumber>),
+            """
+            ... on MirrorValue {
+                    mirrored_items {
+                        mirrored_value {
+                        ... on NumbersValue  {
+                           id
+                           type
+                           value
+                           text
+                        }
+                    }
+                }
+            }
+            """
+        },
+
+        {
+            typeof(ColumnMirror<ColumnDateTime>),
+            """
+            ... on MirrorValue {
+                    mirrored_items {
+                        mirrored_value {
+                        ... on DateValue {
+                           id
+                           type
+                           value
+                           text
+                        }
+                    }
+                }
+            }
+            """
+        },
+
+        {
+            typeof(ColumnMirror<ColumnStatus>),
+            """
+            ... on MirrorValue {
+                    mirrored_items {
+                        mirrored_value {
+            ... on StatusValue {
+               id
+               type
+               value
+               text
+            }
+                        }
+                        }
+                        }
+            """
+        },
     };
 
     /// <summary>
@@ -93,7 +185,6 @@ public static partial class MondayUtilities
 
             PropertyInfo? prop = destinationType.GetProperty(propertyName);
             if (prop == null || !prop.CanWrite) continue;
-
             prop.SetValue(destination, CreateColumnTypeInstance(columnValue.Type, columnValue));
         }
 
@@ -165,13 +256,6 @@ public static partial class MondayUtilities
         return columnPropertyMap;
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="columnType"></param>
-    /// <param name="column"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
     public static object CreateColumnTypeInstance(MondayColumnType? columnType, ColumnValue column)
     {
         // Create The Column Type Instance.
@@ -345,6 +429,70 @@ public static partial class MondayUtilities
                 return new ColumnPeopleAndTeams(column.Id, peopleAndTeams);
             }
             
+            case MondayColumnType.Mirror:
+
+                // Check if there are mirrored items, if not return an empty mirror column
+                if (column.MirroredItems == null || column.MirroredItems.Count == 0)
+                {
+                    return new ColumnMirror<ColumnBaseType>(column.Id, []);
+                }
+
+                // Get the first mirrored item to determine the type of the mirror column
+                MirrorItem? firstMirrorItem = column.MirroredItems.FirstOrDefault();
+
+                // Check all mirrored items to ensure they are of the same type, if not throw an exception
+                if (column.MirroredItems.Any(item => item.MirroredValue?.GetType() != firstMirrorItem?.MirroredValue?.GetType()))
+                {
+                    throw new InvalidOperationException($"Inconsistent mirrored value types in column '{column.Id}'. All mirrored items must be of the same type.");
+                }
+
+                if (firstMirrorItem?.MirroredValue == null)
+                {
+                    throw new InvalidOperationException($"The first mirrored item in column '{column.Id}' has a null mirrored value, cannot determine mirror column type.");
+                }
+
+                if (!SupportedMirrorColumnTypes.TryGetValue(firstMirrorItem.MirroredValue.Type, out Type? mirrorColumnType))
+                {
+                    // TODO: Validate that unsupported types are not used in mirrors at the API level
+                    // and throw an exception here if they are encountered
+                    throw new NotImplementedException($"{firstMirrorItem?.MirroredValue?.Type}");
+                }
+
+                // Get the type of the mirror column based on the first mirrored item
+                Type listType = typeof(List<>).MakeGenericType([mirrorColumnType!]);
+
+                // Create the list instance
+                IList? list = (IList?)Activator.CreateInstance(listType) ?? throw new InvalidOperationException($"Failed to create list instance for type {listType}");
+
+                // Use the type to create the appropriate mirror column instance
+                foreach (MirrorItem mirrorItem in column.MirroredItems)
+                {
+                    // Check if the mirrored value is null, if so skip this item
+                    if (mirrorItem.MirroredValue == null) continue;
+
+                    // Attempt to get the mirrored value using recursion for nested mirrors
+                    object obj = CreateColumnTypeInstance(mirrorItem.MirroredValue.Type, mirrorItem.MirroredValue);
+
+                    // Check if object is of the expected mirror column type, if not throw an exception
+                    if (obj.GetType() != mirrorColumnType)
+                    {
+                        throw new InvalidOperationException(
+                            $"Unexpected mirrored value type in column '{column.Id}'. Expected {mirrorColumnType}, got {obj.GetType()}.");
+                    }
+
+                    // Add the mirrored value to the list
+                    list.Add(obj);
+                }
+
+                // Build the mirror column instance using the list of mirrored values
+                Type mirrorColumnInstanceType = typeof(ColumnMirror<>).MakeGenericType([mirrorColumnType]);
+
+                // Create the mirror column instance
+                var mirrorColumnInstance = Activator.CreateInstance(mirrorColumnInstanceType, column.Id, list) 
+                    ?? throw new InvalidOperationException($"Failed to create mirror column instance for type {mirrorColumnInstanceType}");
+
+                return mirrorColumnInstance;
+
             default:
                 throw new ArgumentException($"Unsupported column type: {columnType}");
         }

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,17 +10,17 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.30</Version>
+        <Version>1.0.31</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GraphQL.Client" Version="6.0.2"/>
-        <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
+        <PackageReference Include="GraphQL.Client" Version="6.1.0" />
+        <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
 </Project>

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -1821,7 +1821,31 @@ public class FunctionalTests
         Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Id == 12254632);
         Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Name == "Andrew Eberle");
     }
-    
+
+    [TestMethod]
+    public async Task Get_Mirrored_Text_Column_Should_Be_Ok()
+    {
+        // Act
+        NET.Application.MondayResponse<MondayTestMirrorRow> mondayResponse =
+            await MondayClient!.GetBoardItemAsync<MondayTestMirrorRow>(this.BoardId);
+        
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsTrue(mondayResponse.Response?.Count > 0);
+        Assert.IsNotNull(mondayResponse.Response?.FirstOrDefault()?.Data?.SomeColumn);
+        Assert.IsNotNull(mondayResponse.Response?.FirstOrDefault()?.Data?.SomeOtherColumn);
+        Assert.IsNotNull(mondayResponse.Response?.FirstOrDefault()?.Data?.AnotherColumn);
+
+    }
+
+    public record MondayTestMirrorRow : MondayRow
+    {
+        [MondayColumnHeader("lookup_mm39q3f2")] public ColumnMirror<ColumnText>? SomeColumn { get; set; }
+        [MondayColumnHeader("lookup_mm39m1yr")] public ColumnMirror<ColumnStatus>? SomeOtherColumn { get; set; }
+        [MondayColumnHeader("lookup_mm39v2p4")] public ColumnMirror<ColumnNumber>? AnotherColumn { get; set; }
+    }
+
+
     public record User : MondayUser
     {
         

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -1827,7 +1827,7 @@ public class FunctionalTests
     {
         // Act
         NET.Application.MondayResponse<MondayTestMirrorRow> mondayResponse =
-            await MondayClient!.GetBoardItemAsync<MondayTestMirrorRow>(this.BoardId);
+            await MondayClient!.GetBoardItemAsync<MondayTestMirrorRow>(11973352090);
         
         // Assert
         Assert.IsTrue(mondayResponse.IsSuccessful);
@@ -1840,8 +1840,8 @@ public class FunctionalTests
 
     public record MondayTestMirrorRow : MondayRow
     {
-        [MondayColumnHeader("lookup_mm39q3f2")] public ColumnMirror<ColumnText>? SomeColumn { get; set; }
-        [MondayColumnHeader("lookup_mm39m1yr")] public ColumnMirror<ColumnStatus>? SomeOtherColumn { get; set; }
+        [MondayColumnHeader("lookup_mm39cb73")] public ColumnMirror<ColumnText>? SomeColumn { get; set; }
+        [MondayColumnHeader("lookup_mm39d6tw")] public ColumnMirror<ColumnStatus>? SomeOtherColumn { get; set; }
         [MondayColumnHeader("lookup_mm39v2p4")] public ColumnMirror<ColumnNumber>? AnotherColumn { get; set; }
     }
 


### PR DESCRIPTION
**Mirror Column Support:**

* Added a new `ColumnMirror<T>` generic record to represent mirror columns, supporting multiple mirrored item types. (`src/MondaySharp.NET/Domain/ColumnTypes/ColumnMirror.cs`)
* Introduced the `MirrorItem` class and updated the `ColumnValue` record to include a `MirroredItems` property for deserializing mirrored data. (`src/MondaySharp.NET/Application/Entities/MirrorItem.cs`,

**Infrastructure and Utility Enhancements:**

* Extended the `MondayUtilities` class to support mapping and instantiation of mirror columns, including new GraphQL fragments for various mirrored types and a robust method for creating mirror column instances with type validation. (`src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs`)

**Testing:**

* Added a functional test and a test row type to verify correct fetching and mapping of mirrored text, status, and number columns. (`tests/MondaySharp.Functional.Tests/FunctionalTests.cs`)

**Dependency and Version Updates:**

* Bumped the package version to 1.0.31 and updated GraphQL dependencies to version 6.1.0. (`src/MondaySharp.NET/MondaySharp.NET.csproj`)