### PR TITLE
Read sub items from get items implementation

### DIFF
--- a/src/MondaySharp.NET/Application/Common/ItemBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Common/ItemBindableSource.cs
@@ -12,6 +12,7 @@ public sealed class ItemBindableSource(Item item) : IMondayBindableSource
     public Board? Board { get; } = item.Board;
     public Group? Group { get; } = item.Group;
     public IReadOnlyList<ColumnValue> ColumnValues { get; } = item.ColumnValues;
+    public IReadOnlyList<SubItem> SubItems { get; } = item.SubItems;
     public IReadOnlyList<Asset> Assets { get; } = item.Assets;
     public IReadOnlyList<Update> Updates { get; } = item.Updates;
     public FileUpload? FileUpload { get; } = item.FileUpload;

--- a/src/MondaySharp.NET/Application/Common/UserBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Common/UserBindableSource.cs
@@ -13,7 +13,8 @@ public sealed class UserBindableSource(MondayUser user) : IMondayBindableSource
     public Board? Board { get; } = null;
     public Group? Group { get; } = null;
     public IReadOnlyList<ColumnValue> ColumnValues { get; } = [];
-    public IReadOnlyList<Asset> Assets { get; } 
-    public IReadOnlyList<Update> Updates { get; }
+    public IReadOnlyList<SubItem> SubItems { get; } = [];
+    public IReadOnlyList<Asset> Assets { get; } = [];
+    public IReadOnlyList<Update> Updates { get; } = [];
     public FileUpload? FileUpload { get; }
 }

--- a/src/MondaySharp.NET/Application/Entities/Item.cs
+++ b/src/MondaySharp.NET/Application/Entities/Item.cs
@@ -20,6 +20,8 @@ public record Item
 
     [JsonProperty("column_values")] public List<ColumnValue> ColumnValues { get; set; } = [];
 
+    [JsonProperty("subitems")] public List<SubItem> SubItems { get; set; } = [];
+
     [JsonProperty("assets")] public List<Asset> Assets { get; set; } = [];
 
     [JsonProperty("updates")] public List<Update> Updates { get; set; } = [];

--- a/src/MondaySharp.NET/Application/Entities/SubItem.cs
+++ b/src/MondaySharp.NET/Application/Entities/SubItem.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace MondaySharp.NET.Application.Entities;
+
+public record SubItem
+{
+    [JsonProperty("id")] public ulong Id { get; set; }
+    [JsonProperty("name")] public string Name { get; set; }
+    [JsonProperty("column_values")] public List<ColumnValue> ColumnValues { get; set; } = [];
+}

--- a/src/MondaySharp.NET/Application/Interfaces/IMondayBindableSource.cs
+++ b/src/MondaySharp.NET/Application/Interfaces/IMondayBindableSource.cs
@@ -15,6 +15,7 @@ public interface IMondayBindableSource
     public Group? Group { get; }
 
     public IReadOnlyList<ColumnValue> ColumnValues { get; }
+    public IReadOnlyList<SubItem> SubItems { get; }
     public IReadOnlyList<Asset> Assets { get; }
     public IReadOnlyList<Update> Updates { get; }
 

--- a/src/MondaySharp.NET/AssemblyInfo.cs
+++ b/src/MondaySharp.NET/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("MondaySharp.Functional.Tests")]

--- a/src/MondaySharp.NET/Domain/Common/MondaySubRow.cs
+++ b/src/MondaySharp.NET/Domain/Common/MondaySubRow.cs
@@ -3,7 +3,7 @@ using MondaySharp.NET.Application.Interfaces;
 
 namespace MondaySharp.NET.Domain.Common;
 
-public record MondayRow : IMondayIdentity
+public record MondaySubRow : IMondayIdentity
 {
     [MondayColumnHeader("id")] public ulong Id { get; set; }
 

--- a/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
+++ b/src/MondaySharp.NET/Infrastructure/Persistence/MondayClient.cs
@@ -316,13 +316,22 @@ public partial class MondayClient : IMondayClient, IDisposable
         // Get each property in instance.
         foreach (PropertyInfo propertyInfo in instance.GetType().GetProperties())
         {
+            // Get the property type.
+            Type propertyType = propertyInfo.PropertyType;
+
+            // Get the effective type if the property is a list.
+            Type effectiveType = propertyType.IsGenericType &&
+                     propertyType.GetGenericTypeDefinition() == typeof(List<>)
+                ? propertyType.GetGenericArguments().FirstOrDefault()?.BaseType ?? propertyType
+                : propertyType;
+
             // Attempt to get the type from the GetItemsQueryBuilder
-            if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(propertyInfo.PropertyType, out string? query))
+            if (MondayUtilities.GetItemsQueryBuilder.TryGetValue(effectiveType, out string? query))
             {
                 // Append the query to the string builder.
                 itemsQueryStringBuilder.Append(query);
             }
-            else if (MondayUtilities.ColumnValueFragments.TryGetValue(propertyInfo.PropertyType, out string? fragment))
+            else if (MondayUtilities.ColumnValueFragments.TryGetValue(effectiveType, out string? fragment))
             {
                 columnValueFragments.Append(fragment);
             }

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -9,13 +9,14 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using GraphQL;
 using MondaySharp.NET.Application.Interfaces;
+using System.ComponentModel.DataAnnotations;
+using System.Collections;
 
 namespace MondaySharp.NET.Infrastructure.Utilities;
 
-public static partial class MondayUtilities
+internal static partial class MondayUtilities
 {
-    [GeneratedRegexAttribute(@"(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])",
-        RegexOptions.Compiled)]
+    [GeneratedRegexAttribute(@"(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])", RegexOptions.Compiled)]
     private static partial Regex UrlFromStringExtractor();
 
     private static CultureInfo Culture => CultureInfo.CurrentCulture;
@@ -25,24 +26,36 @@ public static partial class MondayUtilities
     /// </summary>
     private static readonly Regex UrlRegex = UrlFromStringExtractor();
 
-
-    public static readonly Dictionary<Type, string> GetItemsQueryBuilder = new()
+    // Define the supported types and their corresponding query builders
+    internal static readonly Dictionary<Type, string> GetItemsQueryBuilder = new()
     {
         { typeof(Application.Entities.Group), @"group { id title color archived deleted position }" },
         { typeof(List<Asset>), @"assets { id name public_url url_thumbnail created_at }" },
         { typeof(List<Update>), @"updates (limit: 100) { id text_body }" },
+        { typeof(MondaySubRow),
+            @"subitems { 
+                id 
+                name
+                column_values {
+                  id
+                  text
+                  type
+                  value
+                }
+            }"
+        }
     };
 
     // Define the supported types and their corresponding error messages
-    public static readonly Dictionary<Type, string> UnsupportedTypes = new()
+    internal static readonly Dictionary<Type, string> UnsupportedTypes = new()
     {
         { typeof(Application.Entities.Group), "Multiple Group Properties Are Not Supported." },
         { typeof(List<Asset>), "Multiple Asset Properties Are Not Supported." },
         { typeof(List<Update>), "Multiple Update Properties Are Not Supported." }
     };
-    
+
     // https://developer.monday.com/api-reference/reference/column-values-v2#using-fragments-to-get-column-specific-fields
-    public static readonly Dictionary<Type, string> ColumnValueFragments = new()
+    internal static readonly Dictionary<Type, string> ColumnValueFragments = new()
     {
         {
             typeof(ColumnPeopleAndTeams),
@@ -64,7 +77,7 @@ public static partial class MondayUtilities
     /// <param name="item"></param>
     /// <param name="destination"></param>
     /// <returns></returns>
-    public static bool TryBindColumnData<T>(
+    internal static bool TryBindColumnData<T>(
         IReadOnlyDictionary<string, string> columnPropertyMap,
         IMondayBindableSource source,
         ref T destination)
@@ -75,29 +88,101 @@ public static partial class MondayUtilities
 
         Type destinationType = destination.GetType();
 
+        // Set the common properties if they exist in the destination type.
         SetPropertyIfExists(destinationType, "Group", source.Group, destination);
         SetPropertyIfExists(destinationType, "Assets", source.Assets, destination);
         SetPropertyIfExists(destinationType, "Updates", source.Updates, destination);
 
+        // Loop the main row column values and set the properties if they exist in the destination type.
         foreach (ColumnValue columnValue in source.ColumnValues.Where(x => x.Type != MondayColumnType.Subtasks))
         {
+            _ = TryBindColumnValue(columnPropertyMap, destination, destinationType, columnValue);
+        }
+
+        // Attempt to get any List of SubItems properties on the destination type. If they exist, we will attempt to bind the subitems to them.
+        PropertyInfo? subItemsProperty = destinationType.GetProperties()
+            .FirstOrDefault(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
+                                 && p.PropertyType.GetGenericArguments()[0].BaseType == typeof(MondaySubRow));
+
+        // Get the subItems Type.
+        Type? subItemsDestinationType = subItemsProperty?.PropertyType.GetGenericArguments()
+            .FirstOrDefault(x => x.BaseType == typeof(MondaySubRow));
+
+        // Check if the subItem Type was found.
+        if (subItemsDestinationType == null) return true;
+
+        // Create the blueprint.
+        Type listType = typeof(List<>).MakeGenericType(subItemsDestinationType);
+
+        // Create the list instance.
+        IList? subItemList = (IList?)Activator.CreateInstance(listType);
+
+        // Check if the list was created.
+        if (subItemList == null) return true;
+
+        // If there are no subitem properties, we can return true at this point since there is nothing left to bind.
+        if (subItemsProperty == null || subItemsDestinationType == null) return true;
+
+        // Assign the subItemsList to the destination.
+        subItemsProperty.SetValue(destination, subItemList);
+
+        // Get the MondaySubRow default properties so we can ignore them when binding subitem column values.
+        HashSet<string> subItemDefaultProperties = [.. typeof(MondaySubRow).GetProperties().Select(p => p.Name)];
+
+        // Loop the subitem column values and set the properties if they exist in the destination type.
+        foreach (SubItem subItem in source.SubItems)
+        {
+            // Create a new instance of the subitem type and attempt to bind the column values to it.
+            object? subItemInstance = Activator.CreateInstance(subItemsDestinationType);
+
+            // If the subitem instance is null, continue to the next subitem.
+            if (subItemInstance == null) continue;
+
+            // Loop each of the default properties of the MondaySubRow and attempt
+            // to set them on the subitem instance if they exist in the destination type.
+            // We want to do this before setting the column values because the column values may have the same name as the default properties,
+            foreach (string defaultProperty in subItemDefaultProperties)
+            {
+                // Attempt to get the property value from the subitem.
+                PropertyInfo? property = subItemInstance.GetType().GetProperty(defaultProperty);
+
+                // Check if it was found, should be.
+                if (property == null) continue;
+
+                // Attempt to get the value from the subitem.
+               property.SetValue(subItemInstance, subItem.GetType().GetProperty(defaultProperty)?.GetValue(subItem));
+            }
+
+            // Loop the column values of the subitem and set the properties if they exist in the destination type.
+            foreach (ColumnValue columnValue in subItem.ColumnValues.Where(x => x.Type != MondayColumnType.Subtasks))
+            {
+                _ = TryBindColumnValue(columnPropertyMap, subItemInstance, subItemsDestinationType, columnValue);
+            }
+
+            // Add the subitem instance to the list of subitems on the destination instance.
+            subItemList.Add(subItemInstance);
+        }
+        
+        return true;
+
+        static bool TryBindColumnValue(IReadOnlyDictionary<string, string> columnPropertyMap, object destination, Type destinationType, ColumnValue columnValue)
+        {
             string? rawId = columnValue.Id;
-            if (string.IsNullOrWhiteSpace(rawId)) continue;
+            if (string.IsNullOrWhiteSpace(rawId)) return false;
 
             // normalize variants once
             string noSpaces = rawId.Replace(" ", "");
             string pascal = rawId.Length == 0 ? rawId : char.ToUpper(rawId[0], Culture) + rawId[1..];
 
-            if (!TryResolvePropertyName(columnPropertyMap, rawId, pascal, noSpaces, out string? propertyName)) continue;
-            if (string.IsNullOrWhiteSpace(propertyName)) continue;
+            if (!TryResolvePropertyName(columnPropertyMap, rawId, pascal, noSpaces, out string? propertyName)) return false;
+            if (string.IsNullOrWhiteSpace(propertyName)) return false;
 
             PropertyInfo? prop = destinationType.GetProperty(propertyName);
-            if (prop == null || !prop.CanWrite) continue;
+            if (prop == null || !prop.CanWrite) return false;
 
             prop.SetValue(destination, CreateColumnTypeInstance(columnValue.Type, columnValue));
+            return true;
         }
-
-        return true;
     }
     
     private static bool TryResolvePropertyName(
@@ -136,13 +221,35 @@ public static partial class MondayUtilities
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static Dictionary<string, string> GetColumnPropertyMap<T>()
+    internal static Dictionary<string, string> GetColumnPropertyMap<T>()
     {
         // Create A Map Of Column Ids To Property Names.
         Dictionary<string, string> columnPropertyMap = [];
 
+        // Flatten The Type's Properties And Subitem Properties Into A Single List.
+        List<PropertyInfo> propertyInfos = [];
+
         // Loop Through All Properties In The Type.
         foreach (PropertyInfo property in typeof(T).GetProperties())
+        {
+            // Check If The Property Is A List Of Subitems.
+            if (property.PropertyType.IsGenericType 
+                && property.PropertyType.GetGenericTypeDefinition() == typeof(List<>)
+                && property.PropertyType.GetGenericArguments().FirstOrDefault()?.BaseType == typeof(MondaySubRow))
+            {
+                foreach (PropertyInfo subItemProperty in property.PropertyType.GetGenericArguments().FirstOrDefault()?.GetProperties() ?? [])
+                {
+                    propertyInfos.Add(subItemProperty);
+                }
+
+                continue;
+            }
+
+            propertyInfos.Add(property);
+        }
+
+        // Loop Through All Properties In The Type.
+        foreach (PropertyInfo property in propertyInfos)
         {
             // Attempt to get the MondayColumnHeaderAttribute.
             MondayColumnHeaderAttribute? mondayColumnHeaderAttribute =
@@ -172,7 +279,7 @@ public static partial class MondayUtilities
     /// <param name="column"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public static object CreateColumnTypeInstance(MondayColumnType? columnType, ColumnValue column)
+    internal static object CreateColumnTypeInstance(MondayColumnType? columnType, ColumnValue column)
     {
         // Create The Column Type Instance.
         switch (columnType)
@@ -355,7 +462,7 @@ public static partial class MondayUtilities
     /// </summary>
     /// <param name="columnTypes"></param>
     /// <returns></returns>
-    public static string ToColumnValuesJson(this List<ColumnBaseType>? columnTypes)
+    internal static string ToColumnValuesJson(this List<ColumnBaseType>? columnTypes)
     {
         if (columnTypes == null || columnTypes.Count == 0) return string.Empty;
 
@@ -448,8 +555,8 @@ public static partial class MondayUtilities
             return false;
         }
     }
-    
-    public static IEnumerable<string> BuildErrorMessages(
+
+    internal static IEnumerable<string> BuildErrorMessages(
         IEnumerable<GraphQLError>? errors,
         IReadOnlyDictionary<string, object>? extensions)
     {

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,17 +10,16 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.30</Version>
+        <Version>1.0.31</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GraphQL.Client" Version="6.0.2"/>
-        <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.5"/>
+        <PackageReference Include="GraphQL.Client" Version="6.1.0" />
+        <PackageReference Include="GraphQL.Client.Serializer.Newtonsoft" Version="6.1.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
-
 </Project>

--- a/src/MondaySharp.NET/README.md
+++ b/src/MondaySharp.NET/README.md
@@ -1,221 +1,436 @@
 # MondaySharp.NET
 
-<!---
-[![Build Status](https://your-ci-service.com/your-username/your-repo/badge.svg)](https://your-ci-service.com/your-username/your-repo)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
--->
 
-MondaySharp.NET is a powerful and intuitive C# library for interacting with the Monday.com API. With this library,
-developers can seamlessly integrate Monday.com functionalities into their C# applications, making it easier than ever to
-manage and automate workflows.
+A C# library for interacting with the [Monday.com API](https://developer.monday.com/api-reference/docs). Map Monday.com boards to strongly-typed C# records, then read, create, update, and delete items with minimal boilerplate.
 
-## Features
+## Table of Contents
 
-- **Easy Integration**: Quickly integrate Monday.com features into your C# projects with a clean and straightforward
-  API.
-- **Full API Coverage**: Access the complete range of Monday.com API endpoints, allowing you to interact with boards,
-  items, columns, and more.
-- **Type-Safe Models**: Benefit from type-safe models that reflect the structure of Monday.com entities, providing a
-  robust development experience.
-- **Asynchronous Support**: Leverage asynchronous methods for non-blocking communication with the Monday.com API,
-  ensuring optimal performance.
+- [Installation](#installation)
+- [Setup](#setup)
+- [Defining a Row](#defining-a-row)
+- [Reading Items](#reading-items)
+  - [All items on a board](#all-items-on-a-board)
+  - [Filter by column values](#filter-by-column-values)
+  - [By item ID(s)](#by-item-ids)
+  - [By cursor (pagination)](#by-cursor-pagination)
+  - [Including Groups, Assets, and Updates](#including-groups-assets-and-updates)
+  - [Including Sub-Items](#including-sub-items)
+- [Creating Items](#creating-items)
+  - [Using Item objects](#using-item-objects)
+  - [Using a MondayRow](#using-a-mondayrow)
+- [Updating Items](#updating-items)
+- [Deleting Items](#deleting-items)
+- [Sub-Items](#sub-items)
+  - [Reading sub-items](#reading-sub-items)
+  - [Creating sub-items](#creating-sub-items)
+- [Item Updates (Comments)](#item-updates-comments)
+- [File Uploads](#file-uploads)
+- [Boards](#boards)
+- [Users](#users)
+- [Supported Column Types](#supported-column-types)
+- [Contributing](#contributing)
+- [License](#license)
 
-## Getting Started
-
-The library can be injected via Dependency Injection or you can initialize it manually.
-
-**Initializing**
-
-```csharp
-services.TryAddMondayClient(options =>
-{
-    options.EndPoint = new System.Uri(configuration["mondayUrl"]!);
-    options.Token = configuration["mondayToken"]!;
-});
-
-IMondayClient mondayClient = new MondayClient(this.Logger, options =>
-{
-    options.EndPoint = new System.Uri(configuration["mondayUrl"]!);
-    options.Token = configuration["mondayToken"]!;
-});
-```
-
-**Reading**<br>
-When binding your row to an object, you can create a record inheriting `MondayRow`
-
-```csharp
-public record TestRow : MondayRow
-{
-    [MondayColumnHeader("text0")]
-    public ColumnText? Text { get; set; }
-
-    [MondayColumnHeader("numbers9")]
-    public ColumnNumber? Number { get; set; }
-    public ColumnCheckBox? Checkbox { get; set; }
-    public ColumnStatus? Priority { get; set; }
-}
-```
-
-If you have a property that doesn't conform to your naming convention,
-you can simply add the `MondayColumnHeader` attribute, this will tell the client when attempting to bind the properties
-at runtime to look for this `columnId` instead of using the property name.
-
-If you need to include `Groups, Assets, Updates`  you can add them as a property.
-
-*Here are some example records that were used during testing to validate Assets, Updates and Group were successfully
-binding.*
-
-```csharp
-public record TestRowWithAssets : TestRow
-{
-    public List<Asset>? Assets { get; set; }
-}
-public record TestRowWithUpdates : TestRow
-{
-    public List<Update>? Updates { get; set; }
-}
-public record TestRowWithGroup : TestRow
-{
-    public Group? Group { get; set; }
-}
-```
-
-when the library is creating the query to read the item(s),
-it will detect if there are assets, updates or groups, it will then modify the query as needed.
-
-This way, we are not always requesting the assets, updates or groups, only when you need them.
-
-When required to read a column based
-from [ColumnValues](https://developer.monday.com/api-reference/docs/column-values-v2), you can do the following.
-
-```csharp
-ColumnValue[] columnValues =
-[
-    new ColumnValue()
-    {
-        Id = "text0",
-        Text = "123"
-    },
-    new ColumnValue()
-    {
-        Id = "numbers9",
-        Text = "1"
-    },
-];
-List<TestRow?> items = await this.MondayClient!.GetBoardItemsAsync<TestRow>(this.BoardId, columnValues).ToListAsync();
-```
-
-This will attempt to find any items for the `boardId` along with the `columnValues`.
-If you need items without using the `columnValues`, you can simply do the following
-
-*This will enumerate each result asynchronously*
-
-```csharp
-List<TestRow?> items = await this.MondayClient!.GetBoardItemsAsync<TestRow>(this.BoardId).ToListAsync();
-```
-
-**Creating**<br>
-when required to create an item, you can do the following
-
-```csharp
-Item[] items =[
-    new Item()
-    {
-        Name = "Test Item 1",
-        ColumnValues =
-        [
-            new ColumnValue()
-            {
-                ColumnBaseType = new ColumnText()
-                {
-                    Id = "text0",
-                    Text = "Andrew Eberle"
-                },
-            },
-            new ColumnValue()
-            {
-                ColumnBaseType = new ColumnNumber()
-                {
-                    Id = "numbers9",
-                    Number = 10
-                },
-            },
-        ]
-    },
-     new Item()
-    {
-        Name = "Test Item 2",
-        ColumnValues =
-        [
-            new ColumnValue()
-            {
-                ColumnBaseType = new ColumnText()
-                {
-                    Id = "text0",
-                    Text = "Eberle Andrew"
-                },
-            },
-            new ColumnValue()
-            {
-                ColumnBaseType = new ColumnNumber()
-                {
-                    Id = "numbers9",
-                    Number = 11
-                },
-            },
-        ]
-    }
-];
-
-Dictionary<string, Item>? keyValuePairs = await this.MondayClient!.CreateBoardItemsAsync(BoardId, items);
-```
-
-This will create items into monday with a single request similar to this
-https://developer.monday.com/api-reference/docs/introduction-to-graphql#sample-mutation-1
-
-There are any column types, some supported, some not as I'm still building the library.
-Here is a small example pulled from some unit tests.
-
-```csharp
-// Arrange
-List<ColumnBaseType> columnValues =
-[
-    new ColumnDateTime("date", new DateTime(2023, 11, 29)),
-    new ColumnText("text0", "Andrew Eberle"),
-    new ColumnNumber("numbers", 10),
-    new ColumnLongText("long_text7", "hello,world!"),
-    new ColumnStatus("status_19", "Test"),
-    new ColumnStatus("label", "Test"),
-    new ColumnLongText("long_text", "long text with return \n"),
-    new ColumnDropDown("dropdown", ["Hello", "World"]),
-    new ColumnLink("link", "https://www.google.com", "google!"),
-    new ColumnTag("tags", "21057674,21057675"),
-    new ColumnTimeline("timeline", new DateTime(2023, 11, 29), new DateTime(2023, 12, 29)),
-];
-```
-
-First provide the `columnId` and then filling the rest.
-
-Here is the interface thusfar.
-For detailed usage instructions and examples, refer to the [Documentation](./docs/).
+---
 
 ## Installation
-
-Install the MondaySharp.NET library using NuGet Package Manager:
 
 ```bash
 nuget install MondaySharp.NET
 ```
 
-## Contributing
+---
 
-We welcome contributions! Please check out our [Contributing Guidelines](./CONTRIBUTING.md) for details on how to get
-started.
+## Setup
 
-## License
+Register the client with dependency injection, or instantiate it directly.
 
-MondaySharp.NET is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.
+**Dependency Injection**
+
+```csharp
+services.TryAddMondayClient(options =>
+{
+    options.EndPoint = new Uri(configuration["mondayUrl"]!);
+    options.Token = configuration["mondayToken"]!;
+});
+```
+
+**Manual instantiation**
+
+```csharp
+IMondayClient mondayClient = new MondayClient(logger, options =>
+{
+    options.EndPoint = new Uri(configuration["mondayUrl"]!);
+    options.Token = configuration["mondayToken"]!;
+});
+```
 
 ---
 
-Feel free to customize this description to better fit the specific features and goals of your MondaySharp.NET library.
+## Defining a Row
+
+Create a record that inherits `MondayRow`. Each property maps to a Monday.com column by its **column ID**.
+
+```csharp
+public record ProjectRow : MondayRow
+{
+    // Property name matches the column ID (case-insensitive)
+    public ColumnStatus? Status { get; set; }
+
+    // Use [MondayColumnHeader] when the property name differs from the column ID
+    [MondayColumnHeader("text_abc123")]
+    public ColumnText? Description { get; set; }
+
+    [MondayColumnHeader("date_xyz789")]
+    public ColumnDateTime? DueDate { get; set; }
+
+    [MondayColumnHeader("numbers_def456")]
+    public ColumnNumber? Budget { get; set; }
+}
+```
+
+`MondayRow` provides `Id` (`ulong`) and `Name` (`string?`) automatically.
+
+---
+
+## Reading Items
+
+All read methods return a `MondayResponse<T>` which contains:
+
+| Property | Description |
+|---|---|
+| `IsSuccessful` | Whether the request succeeded |
+| `Response` | `List<MondayData<T>>` — each item wrapped in `MondayData<T>.Data` |
+| `Cursor` | Pagination cursor for the next page |
+| `HasMore` | `true` when a next page is available |
+| `Errors` | `HashSet<string>` of error messages, or `null` |
+
+### All items on a board
+
+```csharp
+MondayResponse<ProjectRow> response = await mondayClient.GetBoardItemsAsync<ProjectRow>(boardId);
+
+foreach (MondayData<ProjectRow> entry in response.Response ?? [])
+{
+    ProjectRow row = entry.Data!;
+    Console.WriteLine($"{row.Id}: {row.Name}");
+}
+```
+
+An optional `limit` parameter controls page size (default `25`, max `500`).
+
+```csharp
+MondayResponse<ProjectRow> response = await mondayClient.GetBoardItemsAsync<ProjectRow>(boardId, limit: 100);
+```
+
+### Filter by column values
+
+```csharp
+ColumnValue[] filters =
+[
+    new() { Id = "text_abc123", Text = "Andrew Eberle" },
+];
+
+MondayResponse<ProjectRow> response =
+    await mondayClient.GetBoardItemsAsync<ProjectRow>(boardId, filters);
+```
+
+### By item ID(s)
+
+```csharp
+MondayResponse<ProjectRow> response =
+    await mondayClient.GetBoardItemsAsync<ProjectRow>([itemId1, itemId2]);
+```
+
+### By cursor (pagination)
+
+Use `HasMore` and `Cursor` to page through large boards.
+
+```csharp
+MondayResponse<ProjectRow> page = await mondayClient.GetBoardItemsAsync<ProjectRow>(boardId, limit: 50);
+
+while (page.HasMore)
+{
+    page = await mondayClient.GetBoardItemsAsync<ProjectRow>(page.Cursor, limit: 50);
+    // process page.Response ...
+}
+```
+
+### Including Groups, Assets, and Updates
+
+Add typed properties to your row record and the library will automatically include the relevant fields in the query.
+
+```csharp
+public record ProjectRowWithExtras : ProjectRow
+{
+    public Group? Group { get; set; }
+    public List<Asset>? Assets { get; set; }
+    public List<Update>? Updates { get; set; }
+}
+
+MondayResponse<ProjectRowWithExtras> response =
+    await mondayClient.GetBoardItemsAsync<ProjectRowWithExtras>(boardId);
+```
+
+---
+
+## Creating Items
+
+### Using Item objects
+
+```csharp
+Item[] items =
+[
+    new()
+    {
+        Name = "Project Alpha",
+        ColumnValues =
+        [
+            new() { ColumnBaseType = new ColumnText()     { Id = "text_abc123", Text = "Andrew Eberle" } },
+            new() { ColumnBaseType = new ColumnNumber()   { Id = "numbers_def456", Number = 10 } },
+            new() { ColumnBaseType = new ColumnStatus()   { Id = "status", Status = "In Progress" } },
+            new() { ColumnBaseType = new ColumnDateTime() { Id = "date_xyz789", Date = new DateTime(2024, 6, 1) } },
+        ]
+    },
+    new()
+    {
+        Name = "Project Beta",
+        ColumnValues =
+        [
+            new() { ColumnBaseType = new ColumnText() { Id = "text_abc123", Text = "Eberle Andrew" } },
+        ]
+    }
+];
+
+MondayResponse<Item> response = await mondayClient.CreateBoardItemsAsync(boardId, items);
+// response.Response[i].Data.Id is populated after creation
+```
+
+### Using a MondayRow
+
+When your record already holds the values you want to write, pass it directly. The library maps each property back to its column ID automatically.
+
+```csharp
+ProjectRow newRow = new()
+{
+    Name = "Project Gamma",
+    Description = new ColumnText() { Text = "Created via MondaySharp.NET" },
+    Budget      = new ColumnNumber() { Number = 5000 },
+    Status      = new ColumnStatus() { Status = "In Progress" },
+    DueDate     = new ColumnDateTime() { Date = new DateTime(2024, 12, 31) },
+};
+
+MondayResponse<ProjectRow> response =
+    await mondayClient.CreateBoardItemsAsync<ProjectRow>(boardId, [newRow]);
+```
+
+---
+
+## Updating Items
+
+Use `UpdateBoardItemsAsync` with a populated row that already has its `Id` set.
+
+```csharp
+// Modify the row retrieved earlier
+existingRow.Status = new ColumnStatus() { Status = "Done" };
+existingRow.Name   = "Project Gamma (Completed)";
+
+MondayResponse<ProjectRow> response =
+    await mondayClient.UpdateBoardItemsAsync<ProjectRow>(boardId, [existingRow]);
+```
+
+---
+
+## Deleting Items
+
+```csharp
+// Delete by Item object (Id must be set)
+MondayResponse<Item> response = await mondayClient.DeleteItemsAsync([item1, item2]);
+```
+
+---
+
+## Sub-Items
+
+### Reading sub-items
+
+Define a record inheriting `MondaySubRow` to map the sub-item's columns, then add a `List<T>` property to your parent row. The library detects the property and includes `subitems { ... }` in the query automatically.
+
+```csharp
+public record TaskSubRow : MondaySubRow
+{
+    [MondayColumnHeader("status")]
+    public ColumnStatus? Status { get; set; }
+
+    [MondayColumnHeader("date0")]
+    public ColumnDateTime? DueDate { get; set; }
+
+    [MondayColumnHeader("numbers8")]
+    public ColumnNumber? Estimate { get; set; }
+}
+
+public record ProjectRowWithSubItems : ProjectRow
+{
+    public List<TaskSubRow> SubItems { get; set; } = [];
+}
+```
+
+```csharp
+MondayResponse<ProjectRowWithSubItems> response =
+    await mondayClient.GetBoardItemsAsync<ProjectRowWithSubItems>(boardId);
+
+foreach (MondayData<ProjectRowWithSubItems> entry in response.Response ?? [])
+{
+    foreach (TaskSubRow subItem in entry.Data!.SubItems)
+    {
+        Console.WriteLine($"  SubItem: {subItem.Name}, Status: {subItem.Status?.Status}");
+    }
+}
+```
+
+`MondaySubRow` provides `Id` and `Name` automatically, just like `MondayRow`.
+
+### Creating sub-items
+
+**Using Item objects**
+
+```csharp
+Item[] subItems =
+[
+    new()
+    {
+        Name = "Task 1",
+        ColumnValues =
+        [
+            new() { ColumnBaseType = new ColumnStatus()   { Id = "status", Status = "In Progress" } },
+            new() { ColumnBaseType = new ColumnDateTime() { Id = "date0",  Date = new DateTime(2024, 6, 1) } },
+        ]
+    },
+    new() { Name = "Task 2" }
+];
+
+MondayResponse<Item> response =
+    await mondayClient.CreateBoardSubItemsAsync(parentItemId, subItems);
+```
+
+**Using a MondayRow**
+
+```csharp
+TaskSubRow[] subRows =
+[
+    new() { Name = "Task 1", Status = new ColumnStatus() { Status = "In Progress" } },
+    new() { Name = "Task 2", Status = new ColumnStatus() { Status = "Done" } },
+];
+
+MondayResponse<TaskSubRow> response =
+    await mondayClient.CreateBoardSubItemsAsync<TaskSubRow>(parentItemId, subRows);
+```
+
+---
+
+## Item Updates (Comments)
+
+```csharp
+Update[] updates =
+[
+    new() { ItemId = itemId, TextBody = "First comment" },
+    new() { ItemId = itemId, TextBody = "Second comment" },
+];
+
+MondayResponse<Update> response = await mondayClient.CreateItemsUpdateAsync(updates);
+```
+
+---
+
+## File Uploads
+
+**Upload to a file column**
+
+```csharp
+item.FileUpload = new FileUpload()
+{
+    ColumnId      = "file_col123",
+    FileName      = "report.pdf",
+    StreamContent = new StreamContent(File.OpenRead("report.pdf")),
+};
+
+MondayResponse<Asset> response = await mondayClient.UploadFileToColumnAsync([item]);
+```
+
+**Upload to an item update**
+
+```csharp
+Update update = new()
+{
+    ItemId     = updateId,
+    FileUpload = new FileUpload()
+    {
+        FileName      = "attachment.txt",
+        StreamContent = new StreamContent(File.OpenRead("attachment.txt")),
+    }
+};
+
+MondayResponse<Asset> response = await mondayClient.UploadFileToUpdateAsync([update]);
+```
+
+---
+
+## Boards
+
+```csharp
+// Fetch specific boards
+MondayResponse<Board> response = await mondayClient.GetBoardsAsync([boardId1, boardId2]);
+
+// Fetch up to 10 boards (default)
+MondayResponse<Board> allBoards = await mondayClient.GetBoardsAsync();
+```
+
+---
+
+## Users
+
+Define a record inheriting `MondayUser` (`Id` and `Name` are provided automatically).
+
+```csharp
+public record AppUser : MondayUser { }
+
+// Fetch all users
+MondayResponse<AppUser> allUsers = await mondayClient.GetUsersAsync<AppUser>();
+
+// Fetch specific users by ID
+MondayResponse<AppUser> specificUsers = await mondayClient.GetUsersAsync<AppUser>([userId1, userId2]);
+```
+
+---
+
+## Supported Column Types
+
+| Type | Class |
+|---|---|
+| Text | `ColumnText` |
+| Number | `ColumnNumber` |
+| Status | `ColumnStatus` |
+| Date | `ColumnDateTime` |
+| Checkbox | `ColumnCheckBox` |
+| Long Text | `ColumnLongText` |
+| Dropdown | `ColumnDropDown` |
+| Link | `ColumnLink` |
+| Tags | `ColumnTag` |
+| Timeline | `ColumnTimeline` |
+| Email | `ColumnEmail` |
+| Phone | `ColumnPhone` |
+| Rating | `ColumnRating` |
+| Color Picker | `ColumnColorPicker` |
+| People & Teams | `ColumnPeopleAndTeams` |
+| File | `ColumnFile` |
+
+---
+
+## Contributing
+
+Contributions are welcome! Please read the [Contributing Guidelines](./CONTRIBUTING.md) before opening a pull request.
+
+## License
+
+MondaySharp.NET is licensed under the MIT License — see the [LICENSE](./LICENSE) file for details.

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -59,7 +59,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -85,7 +85,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "FROM UNIT TEST"
                     }
                 },
@@ -120,7 +120,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -131,7 +131,7 @@ public class FunctionalTests
 
         // Assert
         Assert.IsTrue(items.Response?.Count > 0);
-        Assert.IsTrue(items.Response?.FirstOrDefault()?.Data?.Group?.Id == "new_group53864");
+        Assert.IsTrue(items.Response?.FirstOrDefault()?.Data?.Group?.Id == "topics");
     }
 
     [TestMethod]
@@ -142,7 +142,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             }
         ];
@@ -154,7 +154,7 @@ public class FunctionalTests
                 Name = "Test Item 1",
                 Text = new ColumnText()
                 {
-                    Id = "text0",
+                    Id = "text_mkmn7km4",
                     Text = "FROM UNIT TEST"
                 }
             }
@@ -180,7 +180,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "FROM UNIT TEST"
                     }
                 }
@@ -197,7 +197,7 @@ public class FunctionalTests
         [
             new()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             },
         ];
@@ -224,7 +224,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     },
                 },
@@ -251,7 +251,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -297,7 +297,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     },
                 },
@@ -355,13 +355,13 @@ public class FunctionalTests
         List<ColumnBaseType> columnValues =
         [
             new ColumnDateTime("date", new DateTime(2023, 11, 29)),
-            new ColumnText("text0", "Andrew Eberle"),
+            new ColumnText("text_mkmn7km4", "Andrew Eberle"),
             new ColumnNumber("numbers", 10),
             new ColumnLongText("long_text7", "hello,world!"),
             new ColumnStatus("status_19", "Test"),
             new ColumnStatus("label", "Test"),
             new ColumnLongText("long_text", "long text with return \n"),
-            new ColumnDropDown("dropdown", ["Hello", "World"]),
+            new ColumnDropDown("dropdown", ["1", "World"]),
             new ColumnLink("link", "https://www.google.com", "google!"),
             new ColumnTag("tags", "21057674,21057675"),
             new ColumnTimeline("timeline", new DateTime(2023, 11, 29), new DateTime(2023, 12, 29)),
@@ -379,7 +379,7 @@ public class FunctionalTests
 
         Assert.IsTrue(jsonDocument.RootElement.EnumerateObject().Count() == columnValues.Count);
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("date").GetProperty("date").GetString() == "2023-11-29");
-        Assert.IsTrue(jsonDocument.RootElement.GetProperty("text0").GetString() == "Andrew Eberle");
+        Assert.IsTrue(jsonDocument.RootElement.GetProperty("text_mkmn7km4").GetString() == "Andrew Eberle");
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("numbers").GetString() == "10");
         Assert.IsTrue(jsonDocument.RootElement.GetProperty("long_text7").GetProperty("text").GetString() ==
                       "hello,world!");
@@ -413,14 +413,13 @@ public class FunctionalTests
             new()
             {
                 Name = "Test Item 1",
-                Group = new Group() { Id = "new_group53864" },
                 ColumnValues =
                 [
                     new ColumnValue()
                     {
                         ColumnBaseType = new ColumnText()
                         {
-                            Id = "text0",
+                            Id = "text_mkmn7km4",
                             Text = "Andrew Eberle"
                         }
                     },
@@ -445,14 +444,13 @@ public class FunctionalTests
             new()
             {
                 Name = "Test Item 2",
-                Group = new Group() { Id = "new_group53864" },
                 ColumnValues =
                 [
                     new ColumnValue()
                     {
                         ColumnBaseType = new ColumnText()
                         {
-                            Id = "text0",
+                            Id = "text_mkmn7km4",
                             Text = "Eberle Andrew"
                         }
                     },
@@ -530,7 +528,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -585,7 +583,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "FROM UNIT TEST"
                     }
                 },
@@ -619,14 +617,13 @@ public class FunctionalTests
         Item item = new()
         {
             Name = "Test Item 1",
-            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -643,14 +640,13 @@ public class FunctionalTests
         Item item2 = new()
         {
             Name = "Test Item 2",
-            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Eberle Andrew"
                     }
                 },
@@ -725,14 +721,13 @@ public class FunctionalTests
         Item item = new()
         {
             Name = "Test Item 1",
-            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -740,7 +735,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnNumber()
                     {
-                        Id = "numbers9",
+                        Id = "numeric_mm3b8h2c",
                         Number = 10
                     }
                 }
@@ -749,14 +744,13 @@ public class FunctionalTests
         Item item1 = new()
         {
             Name = "Test Item 2",
-            Group = new Group() { Id = "new_group53864" },
             ColumnValues =
             [
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -764,7 +758,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnNumber()
                     {
-                        Id = "numbers9",
+                        Id = "numeric_mm3b8h2c",
                         Number = 10
                     }
                 }
@@ -791,13 +785,13 @@ public class FunctionalTests
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "files4"
+            ColumnId = "file_mm3bzz98"
         };
         FileUpload fileUpload1 = new()
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "files4"
+            ColumnId = "file_mm3bzz98"
         };
 
         item.FileUpload = fileUpload;
@@ -848,7 +842,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -957,7 +951,7 @@ public class FunctionalTests
             },
             Dropdown = new ColumnDropDown()
             {
-                Label = "Hello"
+                Label = "1"
             },
             LongText = new ColumnLongText()
             {
@@ -974,7 +968,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "Done"
+                Status = "Complete"
             },
             Timeline = new ColumnTimeline()
             {
@@ -1043,7 +1037,7 @@ public class FunctionalTests
             },
             Dropdown = new ColumnDropDown()
             {
-                Label = "Hello"
+                Label = "1"
             },
             LongText = new ColumnLongText()
             {
@@ -1060,7 +1054,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "Done"
+                Status = "Complete"
             },
             Timeline = new ColumnTimeline()
             {
@@ -1155,7 +1149,7 @@ public class FunctionalTests
             },
             Dropdown = new ColumnDropDown()
             {
-                Label = "Hello"
+                Label = "1"
             },
             LongText = new ColumnLongText()
             {
@@ -1172,7 +1166,7 @@ public class FunctionalTests
             },
             Status = new ColumnStatus()
             {
-                Status = "In Testing"
+                Status = "Complete"
             },
             Timeline = new ColumnTimeline()
             {
@@ -1225,7 +1219,7 @@ public class FunctionalTests
 
             Status = new ColumnStatus()
             {
-                Status = "Needs Review"
+                Status = "Complete"
             },
             DueDate = new ColumnDateTime()
             {
@@ -1263,7 +1257,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "Andrew Eberle"
                     }
                 },
@@ -1371,7 +1365,7 @@ public class FunctionalTests
     public async Task ZZZCleanup()
     {
         // Get All Items
-        NET.Application.MondayResponse<TestRow> items = await MondayClient!.GetBoardItemsAsync<TestRow>(BoardId);
+        NET.Application.MondayResponse<TestRow> items = await MondayClient!.GetBoardItemsAsync<TestRow>(BoardId, limit: 34);
 
         // Delete All Items
         await MondayClient!.DeleteItemsAsync([
@@ -1396,7 +1390,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text0",
+                        Id = "text_mkmn7km4",
                         Text = "FROM UNIT TEST"
                     }
                 }
@@ -1425,7 +1419,7 @@ public class FunctionalTests
             Name = "Test Item Create",
             Text = new ColumnText()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             }
         };
@@ -1451,7 +1445,7 @@ public class FunctionalTests
             Name = "Test Item Update Details For Issue 10",
             Group = new Group()
             {
-                Id = "new_group53864"
+                Id = "topics"
             },
             Text = new ColumnText()
             {
@@ -1506,7 +1500,7 @@ public class FunctionalTests
             Name = "Test Item Update Details For Issue 9",
             Group = new Group()
             {
-                Id = "new_group53864"
+                Id = "topics"
             },
             Text = new ColumnText()
             {
@@ -1566,7 +1560,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text__1",
+                        Id = "text_mkmn7km4",
                         Text = "Created with VS Test Case"
                     }
                 },
@@ -1575,14 +1569,14 @@ public class FunctionalTests
                     ColumnBaseType = new ColumnStatus()
                     {
                         Id = "status",
-                        StatusId = 1
+                        Status = "Complete"
                     }
                 },
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnDateTime()
                     {
-                        Id = "date4",
+                        Id = "date_mkp02cdj",
                         Date = DateTime.Now
                     }
                 },
@@ -1591,8 +1585,8 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnDropDown()
                     {
-                        Id = "dropdown__1",
-                        LabelId = 1
+                        Id = "dropdown_mkp0raj0",
+                        Label = "1"
                     }
                 }
             ]
@@ -1615,7 +1609,7 @@ public class FunctionalTests
         {
             FileName = "test.txt",
             StreamContent = new StreamContent(File.OpenRead("test.txt")),
-            ColumnId = "files4"
+            ColumnId = "file_mm3bzz98"
         };
 
         item.FileUpload = fileUpload;
@@ -1644,7 +1638,7 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnText()
                     {
-                        Id = "text__1",
+                        Id = "text_mkmn7km4",
                         Text = "Update With File"
                     }
                 },
@@ -1653,14 +1647,14 @@ public class FunctionalTests
                     ColumnBaseType = new ColumnStatus()
                     {
                         Id = "status",
-                        StatusId = 1
+                        Status = "Complete"
                     }
                 },
                 new ColumnValue()
                 {
                     ColumnBaseType = new ColumnDateTime()
                     {
-                        Id = "date4",
+                        Id = "date_mkp02cdj",
                         Date = DateTime.Now
                     }
                 },
@@ -1669,8 +1663,8 @@ public class FunctionalTests
                 {
                     ColumnBaseType = new ColumnDropDown()
                     {
-                        Id = "dropdown__1",
-                        LabelId = 1
+                        Id = "dropdown_mkp0raj0",
+                        Label = "1"
                     }
                 }
             ]
@@ -1761,7 +1755,7 @@ public class FunctionalTests
             Name = "Test Item Create",
             XeroId = new ColumnText()
             {
-                Id = "text0",
+                Id = "text_mkmn7km4",
                 Text = "FROM UNIT TEST"
             }
         };
@@ -1854,7 +1848,7 @@ public class FunctionalTests
     
     public record Customer : MondayRow
     {
-        [MondayColumnHeader("text0")]
+        [MondayColumnHeader("text_mkmn7km4")]
         public ColumnText? XeroId { get; set; }
     }
     
@@ -1875,53 +1869,53 @@ public class FunctionalTests
 
     public record TestRow : MondayRow
     {
-        [MondayColumnHeader("text0")] public ColumnText? Text { get; set; }
+        [MondayColumnHeader("text_mkmn7km4")] public ColumnText? Text { get; set; }
 
-        [MondayColumnHeader("numbers9")] public ColumnNumber? Number { get; set; }
+        [MondayColumnHeader("numeric_mm3b8h2c")] public ColumnNumber? Number { get; set; }
 
-        [MondayColumnHeader("checkbox")] public ColumnCheckBox? Checkbox { get; set; }
+        [MondayColumnHeader("boolean_mm3b14em")] public ColumnCheckBox? Checkbox { get; set; }
 
-        [MondayColumnHeader("priority")] public ColumnStatus? Priority { get; set; }
+        [MondayColumnHeader("color_mm3b67fc")] public ColumnStatus? Priority { get; set; }
 
         [MondayColumnHeader("status")] public ColumnStatus? Status { get; set; }
 
-        [MondayColumnHeader("link2")] public ColumnLink? Link { get; set; }
+        [MondayColumnHeader("link_mm3b72c7")] public ColumnLink? Link { get; set; }
 
-        [MondayColumnHeader("dropdown")] public ColumnDropDown? Dropdown { get; set; }
+        [MondayColumnHeader("dropdown_mkp0raj0")] public ColumnDropDown? Dropdown { get; set; }
 
-        [MondayColumnHeader("date")] public ColumnDateTime? Date { get; set; }
+        [MondayColumnHeader("date_mkp02cdj")] public ColumnDateTime? Date { get; set; }
 
-        [MondayColumnHeader("long_text")] public ColumnLongText? LongText { get; set; }
+        [MondayColumnHeader("long_text_mm3brcnw")] public ColumnLongText? LongText { get; set; }
 
-        [MondayColumnHeader("color_picker")] public ColumnColorPicker? ColorPicker { get; set; }
+        [MondayColumnHeader("color_picker_mm3b6wfb")] public ColumnColorPicker? ColorPicker { get; set; }
 
-        [MondayColumnHeader("timeline")] public ColumnTimeline? Timeline { get; set; }
+        [MondayColumnHeader("timerange_mm3bf5ee")] public ColumnTimeline? Timeline { get; set; }
 
-        [MondayColumnHeader("tags")] public ColumnTag? Tags { get; set; }
+        [MondayColumnHeader("tag_mm3b8fga")] public ColumnTag? Tags { get; set; }
 
-        [MondayColumnHeader("email")] public ColumnEmail? Email { get; set; }
+        [MondayColumnHeader("email_mm3bgreq")] public ColumnEmail? Email { get; set; }
 
-        [MondayColumnHeader("rating")] public ColumnRating? Rating { get; set; }
+        [MondayColumnHeader("rating_mm3bxehc")] public ColumnRating? Rating { get; set; }
 
-        [MondayColumnHeader("phone_mknbw0n6")] public ColumnPhone? Phone { get; set; }
-        [MondayColumnHeader("multiple_person_mkz16gmv")] public ColumnPeopleAndTeams? Person0 { get; set; }
-        [MondayColumnHeader("multiple_person_mkz17a7w")] public ColumnPeopleAndTeams? Person1 { get; set; }
+        [MondayColumnHeader("phone_mm3bx68a")] public ColumnPhone? Phone { get; set; }
+        [MondayColumnHeader("multiple_person_mm3b64r2")] public ColumnPeopleAndTeams? Person0 { get; set; }
+        [MondayColumnHeader("multiple_person_mkz1hb61")] public ColumnPeopleAndTeams? Person1 { get; set; }
     }
 
     public record Test2Row : MondayRow
     {
-        [MondayColumnHeader("text0")] public ColumnText? Text { get; set; }
+        [MondayColumnHeader("text_mkmn7km4")] public ColumnText? Text { get; set; }
 
         public Group? Group { get; set; }
     }
 
     public record TestSubRow : MondayRow
     {
-        [MondayColumnHeader("color_mkz1z6k6")] public ColumnStatus? Status { get; set; }
+        [MondayColumnHeader("status")] public ColumnStatus? Status { get; set; }
 
-        [MondayColumnHeader("date6")] public ColumnDateTime? DueDate { get; set; }
+        [MondayColumnHeader("date0")] public ColumnDateTime? DueDate { get; set; }
 
-        [MondayColumnHeader("numbers8")] public ColumnNumber? Priority { get; set; }
+        [MondayColumnHeader("numeric_mkp05akm")] public ColumnNumber? Priority { get; set; }
     }
 
     // Fields currently on Test-Board
@@ -1931,12 +1925,12 @@ public class FunctionalTests
 
         [MondayColumnHeader("status")] public ColumnStatus? Status { get; set; }
 
-        [MondayColumnHeader("date")] public ColumnDateTime? Date { get; set; }
+        [MondayColumnHeader("date_mkp02cdj")] public ColumnDateTime? Date { get; set; }
 
-        [MondayColumnHeader("dropdown")] public ColumnDropDown? Dropdown { get; set; }
+        [MondayColumnHeader("dropdown_mkp0raj0")] public ColumnDropDown? Dropdown { get; set; }
 
-        [MondayColumnHeader("text0")] public ColumnText? Text { get; set; }
+        [MondayColumnHeader("text_mkmn7km4")] public ColumnText? Text { get; set; }
 
-        [MondayColumnHeader("files4")] public ColumnFile? Files { get; set; }
+        [MondayColumnHeader("file_mkp0y7rx")] public ColumnFile? Files { get; set; }
     }
 }

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -1821,7 +1821,32 @@ public class FunctionalTests
         Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Id == 12254632);
         Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Name == "Andrew Eberle");
     }
-    
+
+    [TestMethod]
+    public async Task Get_Item_With_SubItem_Should_Be_Ok()
+    {
+        // Act
+        MondayResponse<MondayRowWithSubItems> mondayResponse =
+            await MondayClient!.GetBoardItemsAsync<MondayRowWithSubItems>([11996784006, 11996868487]);
+
+        // Assert
+        Assert.IsTrue(mondayResponse.IsSuccessful);
+        Assert.IsTrue(mondayResponse.Response?.Count == 2);
+        Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.Id == 11996784006);
+        Assert.IsTrue(mondayResponse.Response?.LastOrDefault()?.Data?.Id == 11996868487);
+        Assert.IsTrue(mondayResponse.Response?.FirstOrDefault()?.Data?.SubItems.All(x => x.Id > 0));
+    }
+
+    public record MondayRowWithSubItems : MondayRow
+    {
+        public List<SomeMondaySubRow> SubItems { get; set; } = [];
+    }
+
+    public record SomeMondaySubRow : MondaySubRow
+    {
+        [MondayColumnHeader("numeric_mm33ns9f")] public ColumnNumber? Qty { get; set; }
+    }
+
     public record User : MondayUser
     {
         


### PR DESCRIPTION
**Subitem support and binding enhancements:**

* Added a new `SubItem` entity (`SubItem.cs`) and exposed a `List<SubItem>` property on the `Item` record to represent subitems. 
* Updated `IMondayBindableSource` and related bindable source classes to include a `SubItems` property, ensuring subitems are accessible in the binding layer.
* Enhanced the `MondayUtilities.TryBindColumnData` method to recursively bind subitem properties and their column values to destination types, supporting complex object graphs.
* Improved the `GetItemsQueryBuilder` to include a query fragment for subitems, and updated the property map logic to flatten subitem properties for binding.

**Internal API and dependency updates:**

* Changed several utility classes and methods from `public` to `internal` for better encapsulation, and updated NuGet package dependencies to the latest versions.

* Added an `InternalsVisibleTo` attribute to allow functional tests access to internal members.

**Test updates:**

* Updated test data and assertions in `FunctionalTests.cs` to reflect new column IDs and group IDs, ensuring tests remain valid with the new subitem support and data model changes.

**Updated Readme as it was out of date.**