### PR TITLE
Add support for `LastUpdated` column type with parsing and serialization

### DIFF
--- a/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
+++ b/src/MondaySharp.NET/Application/Entities/ColumnValue.cs
@@ -12,6 +12,8 @@ public record ColumnValue
     [JsonProperty("column")] public Column? Column { get; set; }
 
     [JsonProperty("text")] public string? Text { get; set; }
+    
+    [JsonProperty("value")] public string? Value { get; set; }
 
     [JsonProperty("type")] public MondayColumnType Type { get; set; }
 

--- a/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLastUpdate.cs
+++ b/src/MondaySharp.NET/Domain/ColumnTypes/ColumnLastUpdate.cs
@@ -1,0 +1,31 @@
+    using MondaySharp.NET.Application.Attributes;
+
+    namespace MondaySharp.NET.Domain.ColumnTypes;
+
+    [MondayColumnTypeUnsupportedWrite]
+    public record ColumnLastUpdated : ColumnBaseType
+    {
+        public DateTimeOffset? UpdatedAt { get; set; }
+        public ulong? UpdaterId { get; set; }
+
+        public ColumnLastUpdated(string? id)
+        {
+            Id = id;
+        }
+
+        public ColumnLastUpdated(string? id, DateTimeOffset? updatedAt, ulong? updaterId)
+        {
+            Id = id;
+            UpdatedAt = updatedAt;
+            UpdaterId = updaterId;
+        }
+
+        public ColumnLastUpdated()
+        {
+        }
+
+        public override string ToString()
+        {
+            throw new NotSupportedException(nameof(ColumnLastUpdated));
+        }
+    }

--- a/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
+++ b/src/MondaySharp.NET/Infrastructure/Utilities/MondayUtilties.cs
@@ -11,6 +11,7 @@ using GraphQL;
 using MondaySharp.NET.Application.Interfaces;
 using System.ComponentModel.DataAnnotations;
 using System.Collections;
+using System.Text;
 
 namespace MondaySharp.NET.Infrastructure.Utilities;
 
@@ -460,6 +461,44 @@ internal static partial class MondayUtilities
                 // Return the column people and teams
                 return new ColumnPeopleAndTeams(column.Id, peopleAndTeams);
             }
+            
+            case MondayColumnType.Last_Updated:
+                
+                DateTimeOffset? date = null;
+                ulong? updaterId = null;
+                
+                if (string.IsNullOrEmpty(column.Value))
+                {
+                    return new ColumnLastUpdated(column.Id, null, null);
+                }
+                
+                try
+                {
+                    // Attempt to parse the JSON string.
+                    using JsonDocument jsonDocument = JsonDocument.Parse(column.Value);
+
+                    // Attempt to read the date, it should always be there, but just in case
+                    if (jsonDocument.RootElement.TryGetProperty("updated_at", out JsonElement dateElement) &&
+                        DateTimeOffset.TryParse(dateElement.GetString(), out DateTimeOffset parsedDate))
+                    {
+                        // Set the date
+                        date = parsedDate;
+                    }
+                    
+                    // Attempt to read the updater_id, it should always be there, but just in case
+                    if (jsonDocument.RootElement.TryGetProperty("updater_id", out JsonElement updaterIdElement) && 
+                        ulong.TryParse(updaterIdElement.GetString(), out ulong parsedId))
+                    {
+                        // Set the updater id
+                        updaterId = parsedId;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception, we just want to return the default value
+                }
+ 
+                return new ColumnLastUpdated(column.Id, date, updaterId);
             
             default:
                 throw new ArgumentException($"Unsupported column type: {columnType}");

--- a/src/MondaySharp.NET/MondaySharp.NET.csproj
+++ b/src/MondaySharp.NET/MondaySharp.NET.csproj
@@ -10,7 +10,7 @@
         <PackageDescription>This package contains a Monday.com client</PackageDescription>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Deterministic>False</Deterministic>
-        <Version>1.0.32.0</Version>
+        <Version>1.0.33.0</Version>
         <PackageProjectUrl>https://github.com/andreweberle/MondaySharp.NET/</PackageProjectUrl>
     </PropertyGroup>
 

--- a/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
+++ b/tests/MondaySharp.Functional.Tests/FunctionalTests.cs
@@ -1837,6 +1837,7 @@ public class FunctionalTests
 
     public record SomeMondaySubRow : MondayRow
     {
+        [MondayColumnHeader("pulse_updated_mm3gm5c2")] public ColumnLastUpdated? LastUpdated { get; set; }
         [MondayColumnHeader("numeric_mm33ns9f")] public ColumnNumber? Qty { get; set; }
     }
 


### PR DESCRIPTION
- Introduced `ColumnLastUpdated` record to represent the `LastUpdated` column type, including properties for `UpdatedAt` timestamp and `UpdaterId`.
- Updated the column value parsing logic in `MondayUtilties` to handle `Last_Updated` type, including robust JSON parsing for `updated_at` and `updater_id`.
- Enhanced `ColumnValue` to include an additional `Value` property for processing raw data.
- Added `LastUpdated` column mapping to `SomeMondaySubRow` within functional tests.
- Bumped project version to `1.0.33.0` to reflect new feature addition.